### PR TITLE
Feature/step8

### DIFF
--- a/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
@@ -1,6 +1,8 @@
 package io.hhplus.concert.application.concert;
 
 import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import io.hhplus.concert.domain.concert.model.ConcertSeat;
+import io.hhplus.concert.domain.concert.model.ConcertSeatStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -23,6 +25,26 @@ public class ConcertDto {
             this.startAt = concertSchedule.getStartAt().toString();
             this.endAt = concertSchedule.getEndAt().toString();
             this.createdAt = concertSchedule.getCreatedAt().toString();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ConcertSeatInfo {
+        private final Long id;
+        private final Long concertScheduleId;
+        private final int seatNumber;
+        private final ConcertSeatStatus status;
+        private final int priceAmount;
+        private final String createdAt;
+
+        public ConcertSeatInfo(ConcertSeat concertSeat) {
+            this.id = concertSeat.getId();
+            this.concertScheduleId = concertSeat.getConcertScheduleId();
+            this.seatNumber = concertSeat.getSeatNumber();
+            this.status = concertSeat.getStatus();
+            this.priceAmount = concertSeat.getPriceAmount();
+            this.createdAt = concertSeat.getCreatedAt().toString();
         }
     }
 

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
@@ -16,18 +16,18 @@ public class ConcertDto {
     public static class ConcertScheduleInfo {
         private final Long id;
         private final Long concertId;
-        private final String scheduledAt;
-        private final String startAt;
-        private final String endAt;
-        private final String createdAt;
+        private final LocalDateTime scheduledAt;
+        private final LocalDateTime startAt;
+        private final LocalDateTime endAt;
+        private final LocalDateTime createdAt;
 
         public ConcertScheduleInfo(ConcertSchedule concertSchedule) {
             this.id = concertSchedule.getId();
             this.concertId = concertSchedule.getConcertId();
-            this.scheduledAt = concertSchedule.getScheduledAt().toString();
-            this.startAt = concertSchedule.getStartAt().toString();
-            this.endAt = concertSchedule.getEndAt().toString();
-            this.createdAt = concertSchedule.getCreatedAt().toString();
+            this.scheduledAt = concertSchedule.getScheduledAt();
+            this.startAt = concertSchedule.getStartAt();
+            this.endAt = concertSchedule.getEndAt();
+            this.createdAt = concertSchedule.getCreatedAt();
         }
     }
 
@@ -57,14 +57,16 @@ public class ConcertDto {
         private final Long id;
         private final Long memberId;
         private final Long concertSeatId;
+        private final int paidAmount;
         private final ConcertReservationStatus status;
         private final LocalDateTime reservedAt;
         private final LocalDateTime createdAt;
 
-        public ConcertReservationInfo(ConcertReservation concertReservation) {
+        public ConcertReservationInfo(ConcertReservation concertReservation, ConcertSeat concertSeat) {
             this.id = concertReservation.getId();
             this.memberId = concertReservation.getMemberId();
             this.concertSeatId = concertReservation.getConcertSeatId();
+            this.paidAmount = concertSeat.getPriceAmount();
             this.status = concertReservation.getStatus();
             this.reservedAt = concertReservation.getReservedAt();
             this.createdAt = concertReservation.getCreatedAt();

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
@@ -1,8 +1,11 @@
 package io.hhplus.concert.application.concert;
 
+import io.hhplus.concert.domain.concert.model.ConcertReservation;
+import io.hhplus.concert.domain.concert.model.ConcertReservationStatus;
 import io.hhplus.concert.domain.concert.model.ConcertSchedule;
 import io.hhplus.concert.domain.concert.model.ConcertSeat;
 import io.hhplus.concert.domain.concert.model.ConcertSeatStatus;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -45,6 +48,26 @@ public class ConcertDto {
             this.status = concertSeat.getStatus();
             this.priceAmount = concertSeat.getPriceAmount();
             this.createdAt = concertSeat.getCreatedAt().toString();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ConcertReservationInfo {
+        private final Long id;
+        private final Long memberId;
+        private final Long concertSeatId;
+        private final ConcertReservationStatus status;
+        private final LocalDateTime reservedAt;
+        private final LocalDateTime createdAt;
+
+        public ConcertReservationInfo(ConcertReservation concertReservation) {
+            this.id = concertReservation.getId();
+            this.memberId = concertReservation.getMemberId();
+            this.concertSeatId = concertReservation.getConcertSeatId();
+            this.status = concertReservation.getStatus();
+            this.reservedAt = concertReservation.getReservedAt();
+            this.createdAt = concertReservation.getCreatedAt();
         }
     }
 

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertDto.java
@@ -1,0 +1,29 @@
+package io.hhplus.concert.application.concert;
+
+import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ConcertDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class ConcertScheduleInfo {
+        private final Long id;
+        private final Long concertId;
+        private final String scheduledAt;
+        private final String startAt;
+        private final String endAt;
+        private final String createdAt;
+
+        public ConcertScheduleInfo(ConcertSchedule concertSchedule) {
+            this.id = concertSchedule.getId();
+            this.concertId = concertSchedule.getConcertId();
+            this.scheduledAt = concertSchedule.getScheduledAt().toString();
+            this.startAt = concertSchedule.getStartAt().toString();
+            this.endAt = concertSchedule.getEndAt().toString();
+            this.createdAt = concertSchedule.getCreatedAt().toString();
+        }
+    }
+
+}

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
@@ -1,0 +1,30 @@
+package io.hhplus.concert.application.concert;
+
+import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
+import io.hhplus.concert.domain.concert.ConcertService;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcert;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetReservableConcertSchedules;
+import io.hhplus.concert.domain.concert.model.Concert;
+import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ConcertFacade {
+
+    private final ConcertService concertService;
+
+    public List<ConcertScheduleInfo> getReservableConcertSchedules(Long concertId, LocalDateTime currentTime) {
+        Concert concert = concertService.getConcert(new GetConcert(concertId));
+
+        List<ConcertSchedule> reservableConcertSchedules = concertService.getReservableConcertSchedules(
+            new GetReservableConcertSchedules(concert.getId(), currentTime));
+
+        return reservableConcertSchedules.stream()
+            .map(ConcertDto.ConcertScheduleInfo::new)
+            .toList();
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
@@ -73,6 +73,6 @@ public class ConcertFacade {
         ConcertReservation concertReservation = concertService.createConcertReservation(
             new CreateConcertReservation(member.getId(), concertSeat.getId(), dateTime));
 
-        return new ConcertReservationInfo(concertReservation);
+        return new ConcertReservationInfo(concertReservation, concertSeat);
     }
 }

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
@@ -60,7 +60,7 @@ public class ConcertFacade {
         Member member = memberService.getMember(memberId);
 
         ConcertSeat concertSeat =
-            concertService.getConcertSeat(new GetConcertSeat(concertSeatId));
+            concertService.getConcertSeatWithLock(new GetConcertSeat(concertSeatId));
 
         boolean isReservableSeat =
             concertSeat.isReservable(dateTime, ServicePolicy.TEMP_RESERVE_DURATION_MINUTES);

--- a/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
+++ b/src/main/java/io/hhplus/concert/application/concert/ConcertFacade.java
@@ -1,11 +1,15 @@
 package io.hhplus.concert.application.concert;
 
 import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
+import io.hhplus.concert.application.concert.ConcertDto.ConcertSeatInfo;
 import io.hhplus.concert.domain.concert.ConcertService;
 import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcert;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcertSchedule;
 import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetReservableConcertSchedules;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetReservableConcertSeats;
 import io.hhplus.concert.domain.concert.model.Concert;
 import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import io.hhplus.concert.domain.concert.model.ConcertSeat;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,19 @@ public class ConcertFacade {
 
         return reservableConcertSchedules.stream()
             .map(ConcertDto.ConcertScheduleInfo::new)
+            .toList();
+    }
+
+    public List<ConcertSeatInfo> getReservableConcertSeats(Long concertScheduleId, LocalDateTime currentTime) {
+        GetConcertSchedule scheduleQuery = new GetConcertSchedule(concertScheduleId);
+        ConcertSchedule concertSchedule = concertService.getConcertSchedule(scheduleQuery);
+
+        GetReservableConcertSeats seatsQuery =
+            new GetReservableConcertSeats(concertSchedule.getId(), currentTime);
+        List<ConcertSeat> reservableConcertSeats = concertService.getReservableConcertSeats(seatsQuery);
+
+        return reservableConcertSeats.stream()
+            .map(ConcertDto.ConcertSeatInfo::new)
             .toList();
     }
 }

--- a/src/main/java/io/hhplus/concert/application/member/MemberFacade.java
+++ b/src/main/java/io/hhplus/concert/application/member/MemberFacade.java
@@ -1,0 +1,32 @@
+package io.hhplus.concert.application.member;
+
+import io.hhplus.concert.application.member.MemberPointDto.MemberPointInfo;
+import io.hhplus.concert.domain.member.MemberService;
+import io.hhplus.concert.domain.member.model.Member;
+import io.hhplus.concert.domain.member.model.MemberPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class MemberFacade {
+    private final MemberService memberService;
+
+    public MemberPointInfo getMemberPoint(Long memberId) {
+        Member member = memberService.getMember(memberId);
+
+        MemberPoint memberPoint = memberService.getOrCreateMemberPoint(member.getId());
+        return new MemberPointInfo(memberPoint);
+    }
+
+    @Transactional
+    public MemberPointInfo chargeMemberPoint(Long memberId, int amount) {
+        Member member = memberService.getMember(memberId);
+
+        MemberPoint memberPoint = memberService.getOrCreateMemberPoint(member.getId());
+        memberPoint.chargePoint(amount);
+
+        return new MemberPointInfo(memberPoint);
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/member/MemberPointDto.java
+++ b/src/main/java/io/hhplus/concert/application/member/MemberPointDto.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.application.member;
+
+import io.hhplus.concert.domain.member.model.MemberPoint;
+import lombok.Getter;
+
+public class MemberPointDto {
+
+    @Getter
+    public static class MemberPointInfo {
+        private final Long memberId;
+        private final int pointAmount;
+
+        public MemberPointInfo(MemberPoint memberPoint) {
+            this.memberId = memberPoint.getMemberId();
+            this.pointAmount = memberPoint.getPointAmount();
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/payment/PaymentDto.java
+++ b/src/main/java/io/hhplus/concert/application/payment/PaymentDto.java
@@ -1,0 +1,30 @@
+package io.hhplus.concert.application.payment;
+
+import io.hhplus.concert.domain.payment.model.Payment;
+import io.hhplus.concert.domain.payment.model.PaymentStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PaymentDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class PaymentInfo {
+        private final Long id;
+        private final Long memberId;
+        private final Long reservationId;
+        private final int paidAmount;
+        private final PaymentStatus status;
+        private final LocalDateTime paidAt;
+
+        public PaymentInfo(Payment payment) {
+            this.id = payment.getId();
+            this.memberId = payment.getMemberId();
+            this.reservationId = payment.getReservationId();
+            this.paidAmount = payment.getPaidAmount();
+            this.status = payment.getStatus();
+            this.paidAt = payment.getPaidAt();
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/payment/PaymentFacade.java
+++ b/src/main/java/io/hhplus/concert/application/payment/PaymentFacade.java
@@ -1,0 +1,77 @@
+package io.hhplus.concert.application.payment;
+
+import io.hhplus.concert.application.payment.PaymentDto.PaymentInfo;
+import io.hhplus.concert.domain.common.ServicePolicy;
+import io.hhplus.concert.domain.concert.ConcertService;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcertReservation;
+import io.hhplus.concert.domain.concert.dto.ConcertQuery.GetConcertSeat;
+import io.hhplus.concert.domain.concert.exception.ConcertException;
+import io.hhplus.concert.domain.concert.model.ConcertReservation;
+import io.hhplus.concert.domain.concert.model.ConcertSeat;
+import io.hhplus.concert.domain.member.MemberService;
+import io.hhplus.concert.domain.member.model.MemberPoint;
+import io.hhplus.concert.domain.payment.PaymentService;
+import io.hhplus.concert.domain.payment.dto.PaymentCommand.CreatePayment;
+import io.hhplus.concert.domain.payment.dto.PaymentCommand.CreatePaymentHistory;
+import io.hhplus.concert.domain.payment.model.Payment;
+import io.hhplus.concert.domain.payment.model.PaymentHistory;
+import io.hhplus.concert.domain.payment.model.PaymentStatus;
+import io.hhplus.concert.domain.waitingqueue.WaitingQueueService;
+import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentFacade {
+
+    private final PaymentService paymentService;
+    private final ConcertService concertService;
+    private final MemberService memberService;
+    private final WaitingQueueService waitingQueueService;
+
+    @Transactional
+    public PaymentInfo payment(Long reservationId, String token, LocalDateTime dateTime) {
+        ConcertReservation concertReservation =
+            concertService.getConcertReservation(new GetConcertReservation(reservationId));
+
+        Long concertSeatId = concertReservation.getConcertSeatId();
+        ConcertSeat concertSeat =
+            concertService.getConcertSeatWithLock(new GetConcertSeat(concertSeatId));
+
+        boolean temporarilyReserved = concertSeat.isTemporarilyReserved(dateTime,
+            ServicePolicy.TEMP_RESERVE_DURATION_MINUTES);
+        if (!temporarilyReserved) {
+            throw ConcertException.TEMPORARY_RESERVATION_EXPIRED;
+        }
+
+        int priceAmount = concertSeat.getPriceAmount();
+        // 포인트 차감
+        Long memberId = concertReservation.getMemberId();
+        MemberPoint memberPoint = memberService.getOrCreateMemberPoint(memberId);
+        memberPoint.usePoint(priceAmount);
+
+        // 좌석, 예약 정보 업데이트
+        concertSeat.completeReservation(dateTime);
+        concertReservation.completeReservation(dateTime);
+
+        // 대기열 만료 처리
+        WaitingQueue waitingQueue = waitingQueueService.getWaitingQueue(
+            new GetWaitingQueueCommonQuery(token));
+        waitingQueue.expire();
+
+        // 결제 정보 저장
+        Payment payment = paymentService.createPayment(new CreatePayment(memberId, reservationId,
+            priceAmount, PaymentStatus.PAID, dateTime));
+
+        // 결제 이력 저장
+        PaymentHistory paymentHistory = paymentService.createPaymentHistory(
+            new CreatePaymentHistory(payment.getId(),
+                PaymentStatus.PAID, priceAmount));
+
+        return new PaymentInfo(payment);
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueDto.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueDto.java
@@ -1,4 +1,4 @@
-package io.hhplus.concert.application.waitingqueue.dto;
+package io.hhplus.concert.application.waitingqueue;
 
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -1,11 +1,14 @@
 package io.hhplus.concert.application.waitingqueue;
 
 import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueWithOrderInfo;
 import io.hhplus.concert.domain.common.ServicePolicy;
 import io.hhplus.concert.domain.waitingqueue.WaitingQueueService;
 import io.hhplus.concert.domain.waitingqueue.WaitingQueueTokenGenerator;
 import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueCommand.CreateWaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueWithOrder;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -32,5 +35,13 @@ public class WaitingQueueFacade {
 
         WaitingQueue waitingQueue = waitingQueueService.createWaitingQueue(command);
         return new WaitingQueueInfo(waitingQueue);
+    }
+
+    public WaitingQueueWithOrderInfo getWaitingQueueWithOrder(String token) {
+        GetWaitingQueueCommonQuery query = new GetWaitingQueueCommonQuery(token);
+        WaitingQueueWithOrder waitingQueueWithOrder =
+            waitingQueueService.getWaitingQueueWithOrder(query);
+
+        return new WaitingQueueWithOrderInfo(waitingQueueWithOrder);
     }
 }

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -56,4 +56,13 @@ public class WaitingQueueFacade {
             throw WaitingQueueException.INVALID_WAITING_QUEUE;
         }
     }
+
+    //todo: call by activate scheduler
+    public void activateOldestWaitedQueues() {
+        Long activeCount = waitingQueueService.getActiveCount();
+        int maxActiveCount = ServicePolicy.WAITING_QUEUE_ACTIVATE_COUNT;
+
+        int countToActivate = maxActiveCount - activeCount.intValue();
+        waitingQueueService.activateOldestWaitedQueues(countToActivate);
+    }
 }

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -1,0 +1,36 @@
+package io.hhplus.concert.application.waitingqueue;
+
+import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.domain.common.ServicePolicy;
+import io.hhplus.concert.domain.waitingqueue.WaitingQueueService;
+import io.hhplus.concert.domain.waitingqueue.WaitingQueueTokenGenerator;
+import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueCommand.CreateWaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class WaitingQueueFacade {
+
+    private final WaitingQueueService waitingQueueService;
+    private final WaitingQueueTokenGenerator waitingQueueTokenGenerator;
+
+    public WaitingQueueInfo generateWaitingQueueToken() {
+        String token = waitingQueueTokenGenerator.generateWaitingQueueToken();
+
+        CreateWaitingQueue command = CreateWaitingQueue.createWaitingQueue(token);
+
+        Long activeCount = waitingQueueService.getActiveCount();
+        if(activeCount < ServicePolicy.WAITING_QUEUE_ACTIVATE_COUNT) {
+            LocalDateTime expireAt = LocalDateTime.now()
+                .plusMinutes(ServicePolicy.WAITING_QUEUE_EXPIRED_MINUTES);
+
+            command = CreateWaitingQueue.createActiveQueue(token, expireAt);
+        }
+
+        WaitingQueue waitingQueue = waitingQueueService.createWaitingQueue(command);
+        return new WaitingQueueInfo(waitingQueue);
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -7,6 +7,7 @@ import io.hhplus.concert.domain.waitingqueue.WaitingQueueService;
 import io.hhplus.concert.domain.waitingqueue.WaitingQueueTokenGenerator;
 import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueCommand.CreateWaitingQueue;
 import io.hhplus.concert.domain.waitingqueue.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
+import io.hhplus.concert.domain.waitingqueue.exception.WaitingQueueException;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueWithOrder;
 import java.time.LocalDateTime;
@@ -43,5 +44,16 @@ public class WaitingQueueFacade {
             waitingQueueService.getWaitingQueueWithOrder(query);
 
         return new WaitingQueueWithOrderInfo(waitingQueueWithOrder);
+    }
+
+    // todo: call by interceptor
+    public void validateWaitingQueueToken(String token, LocalDateTime currentTime) {
+        GetWaitingQueueCommonQuery query = new GetWaitingQueueCommonQuery(token);
+        WaitingQueue waitingQueue = waitingQueueService.getWaitingQueue(query);
+
+        boolean available = waitingQueue.isAvailable(currentTime);
+        if(!available) {
+            throw WaitingQueueException.INVALID_WAITING_QUEUE;
+        }
     }
 }

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacade.java
@@ -1,7 +1,7 @@
 package io.hhplus.concert.application.waitingqueue;
 
-import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueInfo;
-import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueWithOrderInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueWithOrderInfo;
 import io.hhplus.concert.domain.common.ServicePolicy;
 import io.hhplus.concert.domain.waitingqueue.WaitingQueueService;
 import io.hhplus.concert.domain.waitingqueue.WaitingQueueTokenGenerator;

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/dto/WaitingQueueDto.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/dto/WaitingQueueDto.java
@@ -1,0 +1,28 @@
+package io.hhplus.concert.application.waitingqueue.dto;
+
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class WaitingQueueDto {
+
+    @Getter
+    @AllArgsConstructor
+    public static class WaitingQueueInfo {
+        private final Long id;
+        private final String token;
+        private final WaitingQueueStatus status;
+        private final LocalDateTime expireAt;
+        private final LocalDateTime createdAt;
+
+        public WaitingQueueInfo(WaitingQueue waitingQueue) {
+            this.id = waitingQueue.getId();
+            this.token = waitingQueue.getToken();
+            this.status = waitingQueue.getStatus();
+            this.expireAt = waitingQueue.getExpireAt();
+            this.createdAt = waitingQueue.getCreatedAt();
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/application/waitingqueue/dto/WaitingQueueDto.java
+++ b/src/main/java/io/hhplus/concert/application/waitingqueue/dto/WaitingQueueDto.java
@@ -2,6 +2,7 @@ package io.hhplus.concert.application.waitingqueue.dto;
 
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueWithOrder;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,6 +24,18 @@ public class WaitingQueueDto {
             this.status = waitingQueue.getStatus();
             this.expireAt = waitingQueue.getExpireAt();
             this.createdAt = waitingQueue.getCreatedAt();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class WaitingQueueWithOrderInfo {
+        private final WaitingQueueInfo waitingQueueInfo;
+        private final Long order;
+
+        public WaitingQueueWithOrderInfo(WaitingQueueWithOrder waitingQueueWithOrder) {
+            this.waitingQueueInfo = new WaitingQueueInfo(waitingQueueWithOrder.getWaitingQueue());
+            this.order = waitingQueueWithOrder.getWaitingOrder();
         }
     }
 }

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertRepository.java
@@ -15,6 +15,8 @@ public interface ConcertRepository {
 
     ConcertSeat getConcertSeat(GetConcertSeat query);
 
+    ConcertSeat getConcertSeatWithLock(GetConcertSeat query);
+
     ConcertReservation saveConcertReservation(ConcertReservation reservation);
 
     Concert getConcert(GetConcert query);

--- a/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/ConcertService.java
@@ -28,6 +28,11 @@ public class ConcertService {
         return concertRepository.getConcertSeat(query);
     }
 
+    @Transactional(readOnly = true)
+    public ConcertSeat getConcertSeatWithLock(GetConcertSeat query) {
+        return concertRepository.getConcertSeatWithLock(query);
+    }
+
     @Transactional
     public ConcertReservation createConcertReservation(CreateConcertReservation command) {
         ConcertReservation concertReservation = new ConcertReservation(command);

--- a/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertErrorCode.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ConcertErrorCode implements DomainErrorCode {
+    NOT_RESERVABLE_SEAT(400, "C_400_1", "ConcertSeat is not reservable"),
     CONCERT_SEAT_NOT_FOUND(404, "C_404_1", "ConcertSeat not found"),
     CONCERT_NOT_FOUND(404, "C_404_2", "Concert not found"),
     CONCERT_SCHEDULE_NOT_FOUND(404, "C_404_3", "ConcertSchedule not found"),

--- a/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertErrorCode.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertErrorCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ConcertErrorCode implements DomainErrorCode {
     NOT_RESERVABLE_SEAT(400, "C_400_1", "ConcertSeat is not reservable"),
+    TEMPORARY_RESERVATION_EXPIRED(400, "C_400_2", "Temporary reservation expired"),
     CONCERT_SEAT_NOT_FOUND(404, "C_404_1", "ConcertSeat not found"),
     CONCERT_NOT_FOUND(404, "C_404_2", "Concert not found"),
     CONCERT_SCHEDULE_NOT_FOUND(404, "C_404_3", "ConcertSchedule not found"),

--- a/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertException.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertException.java
@@ -5,6 +5,9 @@ import io.hhplus.concert.domain.common.exception.DomainException;
 
 public class ConcertException extends DomainException {
 
+    public static ConcertException NOT_RESERVABLE_SEAT =
+        new ConcertException(ConcertErrorCode.NOT_RESERVABLE_SEAT);
+
     public static ConcertException CONCERT_SEAT_NOT_FOUND =
         new ConcertException(ConcertErrorCode.CONCERT_SEAT_NOT_FOUND);
 

--- a/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertException.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/exception/ConcertException.java
@@ -8,6 +8,9 @@ public class ConcertException extends DomainException {
     public static ConcertException NOT_RESERVABLE_SEAT =
         new ConcertException(ConcertErrorCode.NOT_RESERVABLE_SEAT);
 
+    public static ConcertException TEMPORARY_RESERVATION_EXPIRED =
+        new ConcertException(ConcertErrorCode.TEMPORARY_RESERVATION_EXPIRED);
+
     public static ConcertException CONCERT_SEAT_NOT_FOUND =
         new ConcertException(ConcertErrorCode.CONCERT_SEAT_NOT_FOUND);
 

--- a/src/main/java/io/hhplus/concert/domain/concert/model/Concert.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/model/Concert.java
@@ -7,10 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity

--- a/src/main/java/io/hhplus/concert/domain/concert/model/ConcertReservation.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/model/ConcertReservation.java
@@ -10,10 +10,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity

--- a/src/main/java/io/hhplus/concert/domain/concert/model/ConcertSchedule.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/model/ConcertSchedule.java
@@ -7,10 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity

--- a/src/main/java/io/hhplus/concert/domain/concert/model/ConcertSeat.java
+++ b/src/main/java/io/hhplus/concert/domain/concert/model/ConcertSeat.java
@@ -46,6 +46,9 @@ public class ConcertSeat {
     @Column(name = "reserved_at")
     private LocalDateTime reservedAt;
 
+    @Version
+    private Long version;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/io/hhplus/concert/domain/member/model/Member.java
+++ b/src/main/java/io/hhplus/concert/domain/member/model/Member.java
@@ -7,10 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity

--- a/src/main/java/io/hhplus/concert/domain/member/model/MemberPoint.java
+++ b/src/main/java/io/hhplus/concert/domain/member/model/MemberPoint.java
@@ -8,10 +8,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -29,7 +31,7 @@ public class MemberPoint {
     private int pointAmount;
 
     @Column(name = "created_at")
-    private LocalDateTime createdAT;
+    private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;

--- a/src/main/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueTokenGenerator.java
+++ b/src/main/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueTokenGenerator.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.domain.waitingqueue;
+
+public interface WaitingQueueTokenGenerator {
+    String generateWaitingQueueToken();
+}

--- a/src/main/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueTokenGeneratorImpl.java
+++ b/src/main/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueTokenGeneratorImpl.java
@@ -1,0 +1,12 @@
+package io.hhplus.concert.domain.waitingqueue;
+
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WaitingQueueTokenGeneratorImpl implements WaitingQueueTokenGenerator {
+    @Override
+    public String generateWaitingQueueToken() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/io/hhplus/concert/domain/waitingqueue/exception/WaitingQueueErrorCode.java
+++ b/src/main/java/io/hhplus/concert/domain/waitingqueue/exception/WaitingQueueErrorCode.java
@@ -11,6 +11,7 @@ public enum WaitingQueueErrorCode implements DomainErrorCode {
     INVALID_CREATION_INPUT(400, "WQ_400_1", "Invalid input data for WaitingQueue creation."),
     INVALID_RETRIEVAL_INPUT(400, "WQ_400_2", "Invalid input data for WaitingQueue retrieval."),
     INVALID_STATE_NOT_WAITING(400, "WQ_400_3", "Invalid state, should be in waiting status."),
+    INVALID_WAITING_QUEUE(400, "WQ_400_4", "Invalid WaitingQueue"),
     WAITING_QUEUE_NOT_FOUND(404, "WQ_404_1", "WaitingQueue not found");
 
     private final int status;

--- a/src/main/java/io/hhplus/concert/domain/waitingqueue/exception/WaitingQueueException.java
+++ b/src/main/java/io/hhplus/concert/domain/waitingqueue/exception/WaitingQueueException.java
@@ -14,6 +14,9 @@ public class WaitingQueueException extends DomainException {
     public static final WaitingQueueException INVALID_STATE_NOT_WAITING =
         new WaitingQueueException(WaitingQueueErrorCode.INVALID_STATE_NOT_WAITING);
 
+    public static final WaitingQueueException INVALID_WAITING_QUEUE =
+        new WaitingQueueException(WaitingQueueErrorCode.INVALID_WAITING_QUEUE);
+
     public static final WaitingQueueException WAITING_QUEUE_NOT_FOUND =
         new WaitingQueueException(WaitingQueueErrorCode.WAITING_QUEUE_NOT_FOUND);
 

--- a/src/main/java/io/hhplus/concert/infra/db/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/infra/db/concert/ConcertRepositoryImpl.java
@@ -31,6 +31,12 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
+    public ConcertSeat getConcertSeatWithLock(GetConcertSeat query) {
+        return concertSeatJpaRepository.findByIdWithLock(query.getConcertSeatId())
+            .orElseThrow(() -> ConcertException.CONCERT_SEAT_NOT_FOUND);
+    }
+
+    @Override
     public ConcertReservation saveConcertReservation(ConcertReservation reservation) {
         return concertReservationJpaRepository.save(reservation);
     }

--- a/src/main/java/io/hhplus/concert/infra/db/concert/ConcertSeatJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/infra/db/concert/ConcertSeatJpaRepository.java
@@ -1,8 +1,12 @@
 package io.hhplus.concert.infra.db.concert;
 
 import io.hhplus.concert.domain.concert.model.ConcertSeat;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 
@@ -10,4 +14,8 @@ import org.springframework.stereotype.Repository;
 public interface ConcertSeatJpaRepository extends JpaRepository<ConcertSeat, Long> {
 
     List<ConcertSeat> findAllByConcertScheduleId(Long concertScheduleId);
+
+    @Lock(LockModeType.OPTIMISTIC) // 명시적으로 낙관적 락을 사용하도록 설정
+    @Query("SELECT cs FROM ConcertSeat cs WHERE cs.id = :concertSeatId")
+    Optional<ConcertSeat> findByIdWithLock(Long concertSeatId);
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertControllerDocs.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertControllerDocs.java
@@ -20,22 +20,22 @@ import java.util.List;
 @Tag(name = "콘서트 API", description = "콘서트 관련 API")
 public interface ConcertControllerDocs {
 
-    @Operation(summary = "콘서트 목록 조회", description = "콘서트 목록 반환")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "콘서트 목록 반환 성공",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = ConcertItem.class))),
-        @ApiResponse(responseCode = "400", description = "Bad Request",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "404", description = "Not Found",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "500", description = "Internal server error",
-            content = @Content(mediaType = "application/json",
-                schema = @Schema(implementation = ApiErrorResponse.class))),
-    })
-    ApiResult<List<ConcertItem>> getConcerts();
+//    @Operation(summary = "콘서트 목록 조회", description = "콘서트 목록 반환")
+//    @ApiResponses(value = {
+//        @ApiResponse(responseCode = "200", description = "콘서트 목록 반환 성공",
+//            content = @Content(mediaType = "application/json",
+//                schema = @Schema(implementation = ConcertItem.class))),
+//        @ApiResponse(responseCode = "400", description = "Bad Request",
+//            content = @Content(mediaType = "application/json",
+//                schema = @Schema(implementation = ApiErrorResponse.class))),
+//        @ApiResponse(responseCode = "404", description = "Not Found",
+//            content = @Content(mediaType = "application/json",
+//                schema = @Schema(implementation = ApiErrorResponse.class))),
+//        @ApiResponse(responseCode = "500", description = "Internal server error",
+//            content = @Content(mediaType = "application/json",
+//                schema = @Schema(implementation = ApiErrorResponse.class))),
+//    })
+//    ApiResult<List<ConcertItem>> getConcerts();
 
     @SecurityRequirement(name = "queueToken")
     @Operation(summary = "예약 가능 날짜 조회", description = "예약 가능 날짜 목록 반환")

--- a/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/concert/ConcertResponse.java
@@ -1,7 +1,9 @@
 package io.hhplus.concert.interfaces.api.concert;
 
+import io.hhplus.concert.application.concert.ConcertDto.ConcertReservationInfo;
+import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
+import io.hhplus.concert.application.concert.ConcertDto.ConcertSeatInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,13 +36,20 @@ public class ConcertResponse {
         private Long concertScheduleId;
 
         @Schema(description = "콘서트 스케줄 날짜")
-        private LocalDate concertScheduledDate;
+        private LocalDateTime scheduledAt;
 
         @Schema(description = "콘서트 시작 일시")
         private LocalDateTime concertStartAt;
 
         @Schema(description = "콘서트 종료 일시")
         private LocalDateTime concertEndAt;
+
+        public ConcertScheduleItem(ConcertScheduleInfo ConcertScheduleInfo) {
+            this.concertScheduleId = ConcertScheduleInfo.getId();
+            this.scheduledAt = ConcertScheduleInfo.getScheduledAt();
+            this.concertStartAt = ConcertScheduleInfo.getStartAt();
+            this.concertEndAt = ConcertScheduleInfo.getEndAt();
+        }
     }
 
     @Getter
@@ -55,6 +64,12 @@ public class ConcertResponse {
 
         @Schema(description = "콘서트 좌석 가격")
         private int priceAmount;
+
+        public ConcertSeatItem(ConcertSeatInfo concertSeatInfo) {
+            this.concertSeatId = concertSeatInfo.getId();
+            this.seatNumber = concertSeatInfo.getSeatNumber();
+            this.priceAmount = concertSeatInfo.getPriceAmount();
+        }
     }
 
     @Getter
@@ -65,5 +80,10 @@ public class ConcertResponse {
 
         @Schema(description = "결제 할 가격")
         private int priceAmount;
+
+        public ReserveConcertResult(ConcertReservationInfo concertReservationInfo) {
+            this.reservationId = concertReservationInfo.getId();
+            this.priceAmount = concertReservationInfo.getPaidAmount();
+        }
     }
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/member/MemberController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/member/MemberController.java
@@ -1,31 +1,41 @@
 package io.hhplus.concert.interfaces.api.member;
 
+import io.hhplus.concert.application.member.MemberFacade;
+import io.hhplus.concert.application.member.MemberPointDto.MemberPointInfo;
 import io.hhplus.concert.interfaces.api.common.response.ApiResult;
 import io.hhplus.concert.interfaces.api.member.MemberResponse.ChargeMemberPoint;
 import io.hhplus.concert.interfaces.api.member.MemberResponse.GetMemberPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/members")
 @RestController
 public class MemberController implements MemberControllerDocs {
 
+    private final MemberFacade memberFacade;
+
     @GetMapping("/{memberId}/points")
     public ApiResult<GetMemberPoint> getMemberPoint(@PathVariable Long memberId,
         @RequestHeader("X-QUEUE-TOKEN") String token) {
-        return ApiResult.OK(new GetMemberPoint(10_000));
+        MemberPointInfo memberPoint = memberFacade.getMemberPoint(memberId);
+
+        return ApiResult.OK(new GetMemberPoint(memberPoint.getPointAmount()));
     }
 
     @PatchMapping("/{memberId}/points")
     public ApiResult<ChargeMemberPoint> chargeMemberPoint(@PathVariable Long memberId,
         @RequestBody MemberRequest.ChargeMemberPoint request,
         @RequestHeader("X-QUEUE-TOKEN") String token) {
-        return ApiResult.OK(new ChargeMemberPoint(10_000 + request.getAmount()));
+        MemberPointInfo memberPointInfo = memberFacade.chargeMemberPoint(memberId,
+            request.getAmount());
+
+        return ApiResult.OK(new ChargeMemberPoint(memberPointInfo.getPointAmount()));
     }
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/PaymentController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/PaymentController.java
@@ -1,28 +1,31 @@
 package io.hhplus.concert.interfaces.api.payment;
 
+import io.hhplus.concert.application.payment.PaymentDto.PaymentInfo;
+import io.hhplus.concert.application.payment.PaymentFacade;
 import io.hhplus.concert.interfaces.api.common.response.ApiResult;
 import io.hhplus.concert.interfaces.api.payment.PaymentResponse.PaymentResult;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/payments")
 @RestController
 public class PaymentController implements PaymentControllerDocs{
 
+    private final PaymentFacade paymentFacade;
+
     @PostMapping("")
     public ApiResult<PaymentResult> payment(@RequestBody PaymentRequest.Payment request,
         @RequestHeader("X-QUEUE-TOKEN") String token) {
-        return ApiResult.OK(
-            PaymentResult.builder()
-                .concertId(1L)
-                .concertTitle("결제된 콘서트 이름")
-                .seatNumber(17)
-                .paymentId(1L)
-                .paidAmount(10_000)
-                .build()
-        );
+        PaymentInfo paymentInfo = paymentFacade.payment(request.getReservationId(), token,
+            LocalDateTime.now());
+
+        PaymentResult response = PaymentResult.from(paymentInfo);
+        return ApiResult.OK(response);
     }
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/payment/PaymentResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/payment/PaymentResponse.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.interfaces.api.payment;
 
+import io.hhplus.concert.application.payment.PaymentDto.PaymentInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -12,19 +13,25 @@ public class PaymentResponse {
     @Builder
     @AllArgsConstructor
     public static class PaymentResult {
-        @Schema(description = "결제 성공한 콘서트 Id")
-        private Long concertId;
-
-        @Schema(description = "결제 성공한 콘서트 이름")
-        private String concertTitle;
-
-        @Schema(description = "결제 성공한 콘서트 좌석")
-        private int seatNumber;
+        @Schema(description = "콘서트 예약 Id")
+        private Long reservationId;
 
         @Schema(description = "결제 id")
         private Long paymentId;
 
         @Schema(description = "결제 금액")
         private int paidAmount;
+
+        @Schema(description = "결제 시각")
+        private LocalDateTime paidAt;
+
+        public static PaymentResult from(PaymentInfo paymentInfo) {
+            return PaymentResult.builder()
+                .reservationId(paymentInfo.getReservationId())
+                .paymentId(paymentInfo.getId())
+                .paidAmount(paymentInfo.getPaidAmount())
+                .paidAt(paymentInfo.getPaidAt())
+                .build();
+        }
     }
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/waitingqueue/WaitingQueueController.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/waitingqueue/WaitingQueueController.java
@@ -1,11 +1,15 @@
 package io.hhplus.concert.interfaces.api.waitingqueue;
 
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueWithOrderInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueFacade;
 import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;
 import io.hhplus.concert.interfaces.api.common.response.ApiResult;
 import io.hhplus.concert.interfaces.api.waitingqueue.WaitingQueueRequest.CreateQueue;
 import io.hhplus.concert.interfaces.api.waitingqueue.WaitingQueueResponse.CreateQueueToken;
 import io.hhplus.concert.interfaces.api.waitingqueue.WaitingQueueResponse.GetQueue;
 import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,32 +17,28 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/queues")
 @RestController
 public class WaitingQueueController implements WaitingQueueControllerDocs {
 
+    private final WaitingQueueFacade waitingQueueFacade;
+
     @GetMapping
     public ApiResult<GetQueue> GetQueue(@RequestHeader("X-QUEUE-TOKEN") String token) {
-        GetQueue mockData = GetQueue.builder()
-            .order(77L)
-            .remainingWaitingCount(50)
-            .queueStatus(WaitingQueueStatus.WAITING.toString())
-            .expiredAt(LocalDateTime.now().plusMinutes(30))
-            .build();
+        WaitingQueueWithOrderInfo waitingQueueWithOrder =
+            waitingQueueFacade.getWaitingQueueWithOrder(token);
 
-        return ApiResult.OK(mockData);
+        GetQueue response = GetQueue.from(waitingQueueWithOrder);
+        return ApiResult.OK(response);
     }
 
     @PostMapping("/token")
     public ApiResult<CreateQueueToken> createQueue(@RequestBody CreateQueue request) {
+        WaitingQueueInfo waitingQueueWithOrder =
+            waitingQueueFacade.generateWaitingQueueToken();
 
-        CreateQueueToken mockData = CreateQueueToken.builder()
-            .token("fc469731-7a49-4eba-b911-bfeec7e9b341")
-            .order(10L)
-            .queueStatus(WaitingQueueStatus.WAITING.toString())
-            .expiredAt(LocalDateTime.now().plusMinutes(30))
-            .build();
-
-        return ApiResult.OK(mockData);
+        CreateQueueToken response = CreateQueueToken.from(waitingQueueWithOrder);
+        return ApiResult.OK(response);
     }
 }

--- a/src/main/java/io/hhplus/concert/interfaces/api/waitingqueue/WaitingQueueResponse.java
+++ b/src/main/java/io/hhplus/concert/interfaces/api/waitingqueue/WaitingQueueResponse.java
@@ -1,5 +1,7 @@
 package io.hhplus.concert.interfaces.api.waitingqueue;
 
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueWithOrderInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -16,13 +18,25 @@ public class WaitingQueueResponse {
         private final Long order;
 
         @Schema(description = "사용자 앞에 남은 대기자 수")
-        private final int remainingWaitingCount;
+        private final Long remainingWaitingCount;
 
         @Schema(description = "현재 사용자의 대기열에서의 상태값")
         private final String queueStatus;
 
         @Schema(description = "대기열 토큰 만료 일시")
         private final LocalDateTime expiredAt;
+
+        public static GetQueue from(WaitingQueueWithOrderInfo info) {
+            WaitingQueueInfo waitingQueueInfo = info.getWaitingQueueInfo();
+            Long order = info.getOrder();
+
+            return GetQueue.builder()
+                .order(waitingQueueInfo.getId())
+                .remainingWaitingCount(order)
+                .queueStatus(waitingQueueInfo.getStatus().toString())
+                .expiredAt(waitingQueueInfo.getExpireAt())
+                .build();
+        }
     }
 
     @Getter
@@ -40,5 +54,14 @@ public class WaitingQueueResponse {
 
         @Schema(description = "대기열 토큰 만료 일시")
         private final LocalDateTime expiredAt;
+
+        public static CreateQueueToken from(WaitingQueueInfo info) {
+            return CreateQueueToken.builder()
+                .token(info.getToken())
+                .order(info.getId())
+                .queueStatus(info.getStatus().toString())
+                .expiredAt(info.getExpireAt())
+                .build();
+        }
     }
 }

--- a/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
@@ -2,7 +2,6 @@ package io.hhplus.concert.application.concert;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
 import io.hhplus.concert.application.concert.ConcertDto.ConcertSeatInfo;
@@ -10,12 +9,18 @@ import io.hhplus.concert.domain.common.ServicePolicy;
 import io.hhplus.concert.domain.concert.exception.ConcertErrorCode;
 import io.hhplus.concert.domain.concert.exception.ConcertException;
 import io.hhplus.concert.domain.concert.model.Concert;
+import io.hhplus.concert.domain.concert.model.ConcertReservationStatus;
 import io.hhplus.concert.domain.concert.model.ConcertSchedule;
 import io.hhplus.concert.domain.concert.model.ConcertSeat;
 import io.hhplus.concert.domain.concert.model.ConcertSeatStatus;
+import io.hhplus.concert.domain.member.exception.MemberErrorCode;
+import io.hhplus.concert.domain.member.exception.MemberException;
+import io.hhplus.concert.domain.member.model.Member;
 import io.hhplus.concert.infra.db.concert.ConcertJpaRepository;
+import io.hhplus.concert.infra.db.concert.ConcertReservationJpaRepository;
 import io.hhplus.concert.infra.db.concert.ConcertScheduleJpaRepository;
 import io.hhplus.concert.infra.db.concert.ConcertSeatJpaRepository;
+import io.hhplus.concert.infra.db.member.MemberJpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -36,14 +41,23 @@ class ConcertFacadeIntegrationTest {
 
     @Autowired
     private ConcertSeatJpaRepository concertSeatJpaRepository;
+
+    @Autowired
+    private ConcertReservationJpaRepository concertReservationJpaRepository;
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
     
     @Autowired
     private ConcertFacade concertFacade;
 
     @AfterEach
     public void tearDown() {
+        concertJpaRepository.deleteAllInBatch();
         concertScheduleJpaRepository.deleteAllInBatch();
-        concertScheduleJpaRepository.deleteAllInBatch();
+        concertSeatJpaRepository.deleteAllInBatch();
+        concertReservationJpaRepository.deleteAllInBatch();
+        memberJpaRepository.deleteAllInBatch();
     }
 
     @DisplayName("getReservableConcertSchedules() 테스트")
@@ -253,6 +267,161 @@ class ConcertFacadeIntegrationTest {
 
             // then
             assertThat(reservableConcertSeats).hasSize(2);
+        }
+    }
+
+    @DisplayName("reserveConcertSeat() 테스트")
+    @Nested
+    class ReserveConcertSeatTest {
+        @DisplayName("memberId에 해당하는 Member가 없다면 MemberException이 발생한다.")
+        @Test
+        void should_ThrowMemberException_When_MemberNotFound() {
+            // given
+            long concertSeatId = 1L;
+            long memberId = 0L;
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(
+                () -> concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("concertSeatId에 해당하는 ConcertSeat이 없다면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_ConcertSeatNotFound() {
+            // given
+            Member defaultMember = this.createDefaultMember();
+
+            long concertSeatId = 0L;
+            long memberId = defaultMember.getId();
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(
+                () -> concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertErrorCode.CONCERT_SEAT_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("이미 예약이 완료된 좌석이라면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_NotReservableSeat() {
+            // given
+            Member defaultMember = this.createDefaultMember();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat
+                .builder()
+                .concertScheduleId(1L)
+                .seatNumber(1)
+                .status(ConcertSeatStatus.RESERVED_COMPLETE)
+                .priceAmount(10000)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertSeatId = savedSeat.getId();
+            long memberId = defaultMember.getId();
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(
+                () -> concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertErrorCode.NOT_RESERVABLE_SEAT.getMessage());
+        }
+
+        @DisplayName("임시 예약된 좌석이라면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_TempReservedSeat() {
+            // given
+            Member defaultMember = this.createDefaultMember();
+
+            int tempReserveDurationMinutes = ServicePolicy.TEMP_RESERVE_DURATION_MINUTES;
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat
+                .builder()
+                .concertScheduleId(1L)
+                .seatNumber(1)
+                .priceAmount(10000)
+                .tempReservedAt(LocalDateTime.now().plusMinutes(tempReserveDurationMinutes + 1))
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertSeatId = savedSeat.getId();
+            long memberId = defaultMember.getId();
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(
+                () -> concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertErrorCode.NOT_RESERVABLE_SEAT.getMessage());
+        }
+
+        @DisplayName("예약이 완료되면 ConcertReservationInfo를 반환한다.")
+        @Test
+        void should_ReturnConcertReservationInfo_When_CompleteReservation() {
+            // given
+            Member defaultMember = this.createDefaultMember();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat
+                .builder()
+                .concertScheduleId(1L)
+                .seatNumber(1)
+                .status(ConcertSeatStatus.AVAILABLE)
+                .priceAmount(10000)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertSeatId = savedSeat.getId();
+            long memberId = defaultMember.getId();
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when
+            ConcertDto.ConcertReservationInfo reservationInfo =
+                concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime);
+
+            // then
+            assertThat(reservationInfo.getMemberId()).isEqualTo(memberId);
+            assertThat(reservationInfo.getConcertSeatId()).isEqualTo(concertSeatId);
+            assertThat(reservationInfo.getStatus()).isEqualTo(ConcertReservationStatus.PENDING);
+            assertThat(reservationInfo.getReservedAt()).isNotNull();
+        }
+
+        @DisplayName("예약이 완료되면 ConcertSeat의 tempReservedAt이 예약이 완료된 시간으로 업데이트된다.")
+        @Test
+        void should_UpdateTempReservedAt_When_CompleteReservation() {
+            // given
+            Member defaultMember = this.createDefaultMember();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat
+                .builder()
+                .concertScheduleId(1L)
+                .seatNumber(1)
+                .status(ConcertSeatStatus.AVAILABLE)
+                .priceAmount(10000)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertSeatId = savedSeat.getId();
+            long memberId = defaultMember.getId();
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when
+            concertFacade.reserveConcertSeat(concertSeatId, memberId, dateTime);
+
+            // then
+            ConcertSeat updatedSeat = concertSeatJpaRepository.findById(concertSeatId).orElse(null);
+            assertThat(updatedSeat).isNotNull();
+            assertThat(updatedSeat.getTempReservedAt()).isEqualTo(dateTime);
+        }
+
+        public Member createDefaultMember() {
+            return memberJpaRepository.save(Member.builder()
+                .name("name")
+                .email("email")
+                .createdAt(LocalDateTime.now())
+                .build());
         }
     }
 }

--- a/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
@@ -5,12 +5,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
+import io.hhplus.concert.application.concert.ConcertDto.ConcertSeatInfo;
+import io.hhplus.concert.domain.common.ServicePolicy;
 import io.hhplus.concert.domain.concert.exception.ConcertErrorCode;
 import io.hhplus.concert.domain.concert.exception.ConcertException;
 import io.hhplus.concert.domain.concert.model.Concert;
 import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import io.hhplus.concert.domain.concert.model.ConcertSeat;
+import io.hhplus.concert.domain.concert.model.ConcertSeatStatus;
 import io.hhplus.concert.infra.db.concert.ConcertJpaRepository;
 import io.hhplus.concert.infra.db.concert.ConcertScheduleJpaRepository;
+import io.hhplus.concert.infra.db.concert.ConcertSeatJpaRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -28,13 +33,17 @@ class ConcertFacadeIntegrationTest {
 
     @Autowired
     private ConcertScheduleJpaRepository concertScheduleJpaRepository;
+
+    @Autowired
+    private ConcertSeatJpaRepository concertSeatJpaRepository;
     
     @Autowired
     private ConcertFacade concertFacade;
 
     @AfterEach
     public void tearDown() {
-        concertScheduleJpaRepository.deleteAll();
+        concertScheduleJpaRepository.deleteAllInBatch();
+        concertScheduleJpaRepository.deleteAllInBatch();
     }
 
     @DisplayName("getReservableConcertSchedules() 테스트")
@@ -136,6 +145,114 @@ class ConcertFacadeIntegrationTest {
         
             // then
             assertThat(reservableConcertSchedules).hasSize(2);
+        }
+    }
+
+    @DisplayName("getReservableConcertSeats() 테스트")
+    @Nested
+    class GetReservableConcertSeats {
+        @DisplayName("concertScheduleId에 해당하는 ConcertSchedule이 없다면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_ConcertScheduleNotFound() {
+            // given
+            long concertScheduleId = 0L;
+
+            // when, then
+            assertThatThrownBy(() -> concertFacade.getReservableConcertSeats(concertScheduleId, LocalDateTime.now()))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertErrorCode.CONCERT_SCHEDULE_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("입력된 날짜 이후로 예약 가능한 콘서트 좌석이 없으면 빈 리스트가 반환된다.")
+        @Test
+        void should_ReturnEmptyList_When_NoReservableConcertSeats() {
+            // given
+            Concert savedConcert = concertJpaRepository.save(Concert
+                .builder()
+                .title("title")
+                .description("description")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertSchedule savedSchedule = concertScheduleJpaRepository.save(ConcertSchedule
+                .builder()
+                .concertId(savedConcert.getId())
+                .scheduledAt(LocalDateTime.now().plusDays(1))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            LocalDateTime now = LocalDateTime.now();
+
+            // when
+            List<ConcertSeatInfo> reservableConcertSeats =
+                concertFacade.getReservableConcertSeats(savedSchedule.getId(), now);
+
+            // then
+            assertThat(reservableConcertSeats).hasSize(0);
+        }
+
+        @DisplayName("입력된 날짜 이후로 예약 가능한 콘서트 좌석 목록을 반환한다.")
+        @Test
+        void should_ReturnConcertSeatInfoList_When_ExistReservableConcertSeats() {
+            // given
+            int tempReserveDurationMinutes = ServicePolicy.TEMP_RESERVE_DURATION_MINUTES;
+            Concert savedConcert = concertJpaRepository.save(Concert
+                .builder()
+                .title("title")
+                .description("description")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertSchedule savedSchedule = concertScheduleJpaRepository.save(ConcertSchedule
+                .builder()
+                .concertId(savedConcert.getId())
+                .scheduledAt(LocalDateTime.now().plusDays(1))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            LocalDateTime now = LocalDateTime.now();
+
+            concertSeatJpaRepository.saveAll(List.of(
+                ConcertSeat.builder()
+                    .concertScheduleId(savedSchedule.getId())
+                    .seatNumber(1)
+                    .status(ConcertSeatStatus.AVAILABLE)
+                    .priceAmount(10000)
+                    .createdAt(LocalDateTime.now())
+                    .build(),
+                ConcertSeat.builder()
+                    .concertScheduleId(savedSchedule.getId())
+                    .seatNumber(2)
+                    .status(ConcertSeatStatus.AVAILABLE)
+                    .priceAmount(10000)
+                    .createdAt(LocalDateTime.now())
+                    .build(),
+                ConcertSeat.builder()
+                    .concertScheduleId(savedSchedule.getId())
+                    .seatNumber(3)
+                    .status(ConcertSeatStatus.RESERVED_COMPLETE)
+                    .priceAmount(10000)
+                    .createdAt(LocalDateTime.now())
+                    .build(),
+                ConcertSeat.builder()
+                    .concertScheduleId(savedSchedule.getId())
+                    .seatNumber(4)
+                    .priceAmount(10000)
+                    .tempReservedAt(now.plusMinutes(tempReserveDurationMinutes + 1)) //임시예약
+                    .createdAt(LocalDateTime.now())
+                    .build()
+            ));
+
+            // when
+            List<ConcertSeatInfo> reservableConcertSeats =
+                concertFacade.getReservableConcertSeats(savedSchedule.getId(), now);
+
+            // then
+            assertThat(reservableConcertSeats).hasSize(2);
         }
     }
 }

--- a/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/concert/ConcertFacadeIntegrationTest.java
@@ -1,0 +1,141 @@
+package io.hhplus.concert.application.concert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.hhplus.concert.application.concert.ConcertDto.ConcertScheduleInfo;
+import io.hhplus.concert.domain.concert.exception.ConcertErrorCode;
+import io.hhplus.concert.domain.concert.exception.ConcertException;
+import io.hhplus.concert.domain.concert.model.Concert;
+import io.hhplus.concert.domain.concert.model.ConcertSchedule;
+import io.hhplus.concert.infra.db.concert.ConcertJpaRepository;
+import io.hhplus.concert.infra.db.concert.ConcertScheduleJpaRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ConcertFacadeIntegrationTest {
+
+    @Autowired
+    private ConcertJpaRepository concertJpaRepository;
+
+    @Autowired
+    private ConcertScheduleJpaRepository concertScheduleJpaRepository;
+    
+    @Autowired
+    private ConcertFacade concertFacade;
+
+    @AfterEach
+    public void tearDown() {
+        concertScheduleJpaRepository.deleteAll();
+    }
+
+    @DisplayName("getReservableConcertSchedules() 테스트")
+    @Nested
+    class GetReservableConcertSchedulesTest {
+        @DisplayName("concertId에 해당하는 Concert가 없다면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_ConcertNotFound() {
+            // given
+            long concertId = 0L;
+
+            // when, then
+            assertThatThrownBy(() -> concertFacade.getReservableConcertSchedules(concertId, LocalDateTime.now()))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertErrorCode.CONCERT_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("입력된 날짜 이후로 예약 가능한 콘서트 일정이 없으면 빈 리스트가 반환된다.")
+        @Test
+        void should_ReturnEmptyList_When_NoReservableConcertSchedules() {
+            // given
+            Concert savedConcert = concertJpaRepository.save(Concert
+                .builder()
+                .title("title")
+                .description("description")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertId = savedConcert.getId();
+            LocalDateTime now = LocalDateTime.now();
+
+            ConcertSchedule schedule1 = ConcertSchedule.builder()
+                .concertId(concertId)
+                .scheduledAt(now.minusDays(1))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .build();
+
+            ConcertSchedule schedule2 = ConcertSchedule.builder()
+                .concertId(concertId)
+                .scheduledAt(now.minusDays(2))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .build();
+
+            concertScheduleJpaRepository.saveAll(List.of(schedule1, schedule2));
+
+            // when
+            List<ConcertScheduleInfo> reservableConcertSchedules =
+                concertFacade.getReservableConcertSchedules(concertId, now);
+
+            // then
+            assertThat(reservableConcertSchedules).hasSize(0);
+        }
+
+        @DisplayName("입력된 날짜 이후로 예약 가능한 콘서트 일정 목록을 반환한다.")
+        @Test
+        void should_ReturnConcertScheduleInfoList_When_ExistReservableConcertSchedules() {
+            // given
+            Concert savedConcert = concertJpaRepository.save(Concert
+                .builder()
+                .title("title")
+                .description("description")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            long concertId = savedConcert.getId();
+            LocalDateTime now = LocalDateTime.now();
+
+            ConcertSchedule schedule1 = ConcertSchedule.builder()
+                .concertId(concertId)
+                .scheduledAt(now.minusDays(1))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            ConcertSchedule schedule2 = ConcertSchedule.builder()
+                .concertId(concertId)
+                .scheduledAt(now.plusDays(1))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            ConcertSchedule schedule3 = ConcertSchedule.builder()
+                .concertId(concertId)
+                .scheduledAt(now.plusDays(2))
+                .startAt(LocalDateTime.now().plusDays(1).plusHours(1))
+                .endAt(LocalDateTime.now().plusDays(1).plusHours(2))
+                .createdAt(LocalDateTime.now())
+                .build();
+
+            concertScheduleJpaRepository.saveAll(List.of(schedule1, schedule2, schedule3));
+
+            // when
+            List<ConcertScheduleInfo> reservableConcertSchedules =
+                concertFacade.getReservableConcertSchedules(concertId, now);
+        
+            // then
+            assertThat(reservableConcertSchedules).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/io/hhplus/concert/application/member/MemberFacadeTest.java
+++ b/src/test/java/io/hhplus/concert/application/member/MemberFacadeTest.java
@@ -1,0 +1,172 @@
+package io.hhplus.concert.application.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.hhplus.concert.domain.member.exception.MemberErrorCode;
+import io.hhplus.concert.domain.member.exception.MemberException;
+import io.hhplus.concert.domain.member.model.Member;
+import io.hhplus.concert.domain.member.model.MemberPoint;
+import io.hhplus.concert.infra.db.member.MemberJpaRepository;
+import io.hhplus.concert.infra.db.member.MemberPointJpaRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MemberFacadeTest {
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @Autowired
+    private MemberPointJpaRepository memberPointJpaRepository;
+
+    @Autowired
+    private MemberFacade memberFacade;
+
+    @AfterEach
+    public void tearDown() {
+        memberPointJpaRepository.deleteAllInBatch();
+        memberJpaRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("getMemberPoint()")
+    @Nested
+    class GetMemberPoint {
+        @DisplayName("memberId에 해당하는 Member가 없으면 MemberException이 발생한다.")
+        @Test
+        void should_ThrowMemberException_WhenMemberNotFound() {
+            // given
+            Long memberId = 0L;
+
+            // when, then
+            assertThatThrownBy(() -> memberFacade.getMemberPoint(memberId))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("memberId에 해당하는 MemberPoint가 없으면 MemberPoint를 생성한다.")
+        @Test
+        void should_CreateMemberPoint_WhenMemberPointNotFound() {
+            // given
+            Member savedMember = memberJpaRepository.save(Member.builder()
+                .name("name")
+                .email("email@email.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            Long memberId = savedMember.getId();
+
+            // when
+            MemberPointDto.MemberPointInfo memberPointInfo = memberFacade.getMemberPoint(memberId);
+
+            // then
+            assertThat(memberPointInfo).isNotNull();
+            assertThat(memberPointInfo.getMemberId()).isEqualTo(memberId);
+            assertThat(memberPointInfo.getPointAmount()).isEqualTo(0);
+        }
+
+        @DisplayName("memberId에 해당하는 MemberPoint가 있으면 해당 MemberPoint를 반환한다.")
+        @Test
+        void should_ReturnMemberPoint_WhenMemberPointFound() {
+            // given
+            Member savedMember = memberJpaRepository.save(Member.builder()
+                .name("name")
+                .email("email@email.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            Long memberId = savedMember.getId();
+
+            MemberPoint savedMemberPoint = memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(100)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            MemberPointDto.MemberPointInfo memberPointInfo = memberFacade.getMemberPoint(memberId);
+
+            // then
+            assertThat(memberPointInfo).isNotNull();
+            assertThat(memberPointInfo.getMemberId()).isEqualTo(memberId);
+            assertThat(memberPointInfo.getPointAmount()).isEqualTo(100);
+        }
+    }
+
+    @DisplayName("chargeMemberPoint()")
+    @Nested
+    class ChargeMemberPoint {
+
+        @DisplayName("memberId에 해당하는 Member가 없으면 MemberException이 발생한다.")
+        @Test
+        void should_ThrowMemberException_WhenMemberNotFound() {
+            // given
+            Long memberId = 0L;
+            int amount = 100;
+
+            // when, then
+            assertThatThrownBy(() -> memberFacade.chargeMemberPoint(memberId, amount))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(MemberErrorCode.MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("memberId에 해당하는 MemberPoint가 없으면 MemberPoint를 생성하고 point를 충전한다.")
+        @Test
+        void should_CreateMemberPointAndChargePoint_WhenMemberPointNotFound() {
+            // given
+            Member savedMember = memberJpaRepository.save(Member.builder()
+                .name("name")
+                .email("email@email.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            Long memberId = savedMember.getId();
+            int amount = 100;
+
+            // when
+            MemberPointDto.MemberPointInfo memberPointInfo = memberFacade.chargeMemberPoint(
+                memberId, amount);
+
+            // then
+            assertThat(memberPointInfo).isNotNull();
+            assertThat(memberPointInfo.getMemberId()).isEqualTo(memberId);
+            assertThat(memberPointInfo.getPointAmount()).isEqualTo(amount);
+        }
+
+        @DisplayName("memberId에 해당하는 MemberPoint가 있으면 point를 충전한다.")
+        @Test
+        void should_ChargePoint_WhenMemberPointFound() {
+            // given
+            Member savedMember = memberJpaRepository.save(Member.builder()
+                .name("name")
+                .email("email@email.com")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            Long memberId = savedMember.getId();
+            int amount = 100;
+
+            MemberPoint savedMemberPoint = memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(100)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            MemberPointDto.MemberPointInfo memberPointInfo = memberFacade.chargeMemberPoint(
+                memberId, amount);
+
+            // then
+            assertThat(memberPointInfo).isNotNull();
+            assertThat(memberPointInfo.getMemberId()).isEqualTo(memberId);
+            assertThat(memberPointInfo.getPointAmount()).isEqualTo(200);
+        }
+    }
+}

--- a/src/test/java/io/hhplus/concert/application/payment/PaymentFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/payment/PaymentFacadeIntegrationTest.java
@@ -1,0 +1,363 @@
+package io.hhplus.concert.application.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.hhplus.concert.application.payment.PaymentDto.PaymentInfo;
+import io.hhplus.concert.domain.common.ServicePolicy;
+import io.hhplus.concert.domain.concert.exception.ConcertException;
+import io.hhplus.concert.domain.concert.model.ConcertReservation;
+import io.hhplus.concert.domain.concert.model.ConcertReservationStatus;
+import io.hhplus.concert.domain.concert.model.ConcertSeat;
+import io.hhplus.concert.domain.concert.model.ConcertSeatStatus;
+import io.hhplus.concert.domain.member.exception.MemberPointErrorCode;
+import io.hhplus.concert.domain.member.exception.MemberPointException;
+import io.hhplus.concert.domain.member.model.MemberPoint;
+import io.hhplus.concert.domain.payment.model.Payment;
+import io.hhplus.concert.domain.payment.model.PaymentStatus;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;
+import io.hhplus.concert.infra.db.concert.ConcertReservationJpaRepository;
+import io.hhplus.concert.infra.db.concert.ConcertSeatJpaRepository;
+import io.hhplus.concert.infra.db.member.MemberPointJpaRepository;
+import io.hhplus.concert.infra.db.payment.PaymentJpaRepository;
+import io.hhplus.concert.infra.db.waitingqueue.WaitingQueueJpaRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PaymentFacadeIntegrationTest {
+
+    @Autowired
+    private PaymentFacade paymentFacade;
+
+    @Autowired
+    private PaymentJpaRepository paymentJpaRepository;
+
+    @Autowired
+    private MemberPointJpaRepository memberPointJpaRepository;
+
+    @Autowired
+    private WaitingQueueJpaRepository waitingQueueJpaRepository;
+
+    @Autowired
+    private ConcertSeatJpaRepository concertSeatJpaRepository;
+
+    @Autowired
+    private ConcertReservationJpaRepository concertReservationJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        paymentJpaRepository.deleteAllInBatch();
+        memberPointJpaRepository.deleteAllInBatch();
+        waitingQueueJpaRepository.deleteAllInBatch();
+        concertSeatJpaRepository.deleteAllInBatch();
+        concertReservationJpaRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("payment() 테스트")
+    @Nested
+    class PaymentTest {
+        @DisplayName("reservationId에 해당하는 ConcertReservation이 존재하지 않으면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_ConcertReservationNotFound() {
+            // given
+            Long reservationId = 1L;
+            String token = "token";
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(() -> paymentFacade.payment(reservationId, token, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertException.CONCERT_RESERVATION_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("reservationId에 해당하는 ConcertReservation의 ConcertSeat이 존재하지 않으면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_ConcertSeatNotFound() {
+            // given
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(1L)
+                    .concertSeatId(0L)
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+            String token = "token";
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            // when, then
+            assertThatThrownBy(() -> paymentFacade.payment(reservationId, token, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertException.CONCERT_SEAT_NOT_FOUND.getMessage());
+        }
+
+        @DisplayName("ConcertSeat이 임시 예약이 만료되면 ConcertException이 발생한다.")
+        @Test
+        void should_ThrowConcertException_When_TemporaryReservationExpired() {
+            // given
+            int tempReserveDurationMinutes = ServicePolicy.TEMP_RESERVE_DURATION_MINUTES;
+            String token = "token";
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime.minusMinutes(tempReserveDurationMinutes + 1))
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(1L)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+
+            // when, then
+            assertThatThrownBy(() -> paymentFacade.payment(reservationId, token, dateTime))
+                .isInstanceOf(ConcertException.class)
+                .hasMessage(ConcertException.TEMPORARY_RESERVATION_EXPIRED.getMessage());
+        }
+
+        @DisplayName("포인트 잔액이 부족하면 MemberException이 발생한다.")
+        @Test
+        void should_ThrowMemberPointException_When_PointIsNotEnough() {
+            // given
+            Long memberId = 1L;
+            String token = "token";
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(memberId)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+
+            memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(0)
+                .build());
+
+            // when, then
+            assertThatThrownBy(() -> paymentFacade.payment(reservationId, token, dateTime))
+                .isInstanceOf(MemberPointException.class)
+                .hasMessage(MemberPointErrorCode.INSUFFICIENT_POINT_AMOUNT.getMessage());
+        }
+
+        @DisplayName("결제가 정상적으로 이뤄지면 포인트가 ConcertSeat의 가격만큼 차감된다.")
+        @Test
+        void should_DecreasePoint_When_PaymentIsSuccessful() {
+            // given
+            Long memberId = 1L;
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(memberId)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+            String token = "token";
+
+            memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(20000)
+                .build());
+
+            waitingQueueJpaRepository.save(WaitingQueue.builder()
+                .token(token)
+                .status(WaitingQueueStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            paymentFacade.payment(reservationId, token, dateTime);
+
+            // then
+            MemberPoint updatedMemberPoint = memberPointJpaRepository.findByMemberId(memberId).orElseThrow();
+            assertThat(updatedMemberPoint.getPointAmount()).isEqualTo(10000);
+        }
+
+        @DisplayName("결제가 정상적으로 이뤄지면 Concert 좌석과 예약의 상태가 바뀐다.")
+        @Test
+        void should_CompleteConcertSeatReservation_When_PaymentIsSuccessful() {
+            // given
+            Long memberId = 1L;
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(memberId)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+            String token = "token";
+
+            memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(20000)
+                .build());
+
+            waitingQueueJpaRepository.save(WaitingQueue.builder()
+                .token(token)
+                .status(WaitingQueueStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            paymentFacade.payment(reservationId, token, dateTime);
+
+            // then
+            ConcertReservation updatedReservation = concertReservationJpaRepository.findById(reservationId).orElseThrow();
+
+            assertThat(updatedReservation.getStatus()).isEqualTo(ConcertReservationStatus.COMPLETED);
+            assertThat(updatedReservation.getReservedAt()).isEqualTo(dateTime);
+
+            ConcertSeat updatedSeat = concertSeatJpaRepository.findById(savedSeat.getId())
+                .orElse(null);
+            assertThat(updatedSeat).isNotNull();
+            assertThat(updatedSeat.getStatus()).isEqualTo(ConcertSeatStatus.RESERVED_COMPLETE);
+            assertThat(updatedSeat.getReservedAt()).isEqualTo(dateTime);
+        }
+
+        @DisplayName("결제가 정상적으로 이뤄지면 대기열이 만료된다.")
+        @Test
+        void should_ExpireWaitingQueue_When_PaymentIsSuccessful() {
+            // given
+            Long memberId = 1L;
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(memberId)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+            String token = "token";
+
+            memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(20000)
+                .build());
+
+            waitingQueueJpaRepository.save(WaitingQueue.builder()
+                .token(token)
+                .status(WaitingQueueStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            paymentFacade.payment(reservationId, token, dateTime);
+
+            // then
+            WaitingQueue updatedWaitingQueue = waitingQueueJpaRepository.findByToken(token).orElseThrow();
+            assertThat(updatedWaitingQueue.getStatus()).isEqualTo(WaitingQueueStatus.EXPIRED);
+        }
+
+        @DisplayName("결제가 정상적으로 이뤄지면 Payment과 PaymentHistory가 생성된다.")
+        @Test
+        void should_CreatePaymentAndPaymentHistory_When_PaymentIsSuccessful() {
+            // given
+            Long memberId = 1L;
+            String token = "token";
+            LocalDateTime dateTime = LocalDateTime.now();
+
+            ConcertSeat savedSeat = concertSeatJpaRepository.save(ConcertSeat.builder()
+                .concertScheduleId(1L)
+                .seatNumber(10)
+                .priceAmount(10000)
+                .tempReservedAt(dateTime)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            ConcertReservation savedReservation = concertReservationJpaRepository.save(
+                ConcertReservation.builder()
+                    .memberId(memberId)
+                    .concertSeatId(savedSeat.getId())
+                    .status(ConcertReservationStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build());
+
+            Long reservationId = savedReservation.getId();
+
+            memberPointJpaRepository.save(MemberPoint.builder()
+                .memberId(memberId)
+                .pointAmount(20000)
+                .build());
+
+            waitingQueueJpaRepository.save(WaitingQueue.builder()
+                .token(token)
+                .status(WaitingQueueStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+            // when
+            PaymentInfo paymentInfo = paymentFacade.payment(reservationId, token, dateTime);
+
+            // then
+            Payment payment = paymentJpaRepository.findById(paymentInfo.getId())
+                .orElse(null);
+            assertThat(payment).isNotNull();
+            assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+            assertThat(payment.getPaidAmount()).isEqualTo(10000);
+        }
+    }
+
+}

--- a/src/test/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacadeIntegrationTest.java
@@ -1,0 +1,76 @@
+package io.hhplus.concert.application.waitingqueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.domain.common.ServicePolicy;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueue;
+import io.hhplus.concert.domain.waitingqueue.model.WaitingQueueStatus;
+import io.hhplus.concert.infra.db.waitingqueue.WaitingQueueJpaRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class WaitingQueueFacadeIntegrationTest {
+
+    @Autowired
+    private WaitingQueueJpaRepository waitingQueueJpaRepository;
+
+    @Autowired
+    private WaitingQueueFacade waitingQueueFacade;
+
+    @AfterEach
+    public void tearDown() {
+        waitingQueueJpaRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("generateWaitingQueueToken() 테스트")
+    @Nested
+    class GenerateWaitingQueueToken {
+        @DisplayName("대기열에 활성화된 사용자가 가용인원보다 적을 때 활성화된 WaitingQueue를 생성한다.")
+        @Test
+        void should_CreateActiveWaitingQueue_When_LessThenMaxActivateCount () {
+            // given
+            waitingQueueJpaRepository.deleteAll();
+
+            // when
+            WaitingQueueInfo waitingQueueInfo = waitingQueueFacade.generateWaitingQueueToken();
+
+            // then
+            assertThat(waitingQueueInfo.getStatus()).isEqualTo(WaitingQueueStatus.ACTIVE);
+            assertThat(waitingQueueInfo.getExpireAt()).isAfter(LocalDateTime.now());
+        }
+
+        @DisplayName("대기열에 활성화된 사용자가 가용인원만큼 있을 때 대기상태인 WaitingQueue를 생성한다.")
+        @Test
+        void should_CreateWaitingStatusWaitingQueue_When_NotLessThenMaxActivateCount () {
+            // given
+            int maxActivateCount = ServicePolicy.WAITING_QUEUE_ACTIVATE_COUNT;
+
+            List<WaitingQueue> waitingQueueList = new ArrayList<>();
+            for (int i = 0; i < maxActivateCount; ++i) {
+                WaitingQueue waitingQueue = new WaitingQueue(null, "token" + i,
+                    WaitingQueueStatus.ACTIVE, LocalDateTime.now().plusMinutes(1),
+                    LocalDateTime.now(), null);
+
+                waitingQueueList.add(waitingQueue);
+            }
+
+            waitingQueueJpaRepository.saveAll(waitingQueueList);
+
+            // when
+            WaitingQueueInfo waitingQueueInfo = waitingQueueFacade.generateWaitingQueueToken();
+
+            // then
+            assertThat(waitingQueueInfo.getStatus()).isEqualTo(WaitingQueueStatus.WAITING);
+            assertThat(waitingQueueInfo.getExpireAt()).isNull();
+        }
+    }
+}

--- a/src/test/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacadeIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/application/waitingqueue/WaitingQueueFacadeIntegrationTest.java
@@ -3,8 +3,8 @@ package io.hhplus.concert.application.waitingqueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueInfo;
-import io.hhplus.concert.application.waitingqueue.dto.WaitingQueueDto.WaitingQueueWithOrderInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueInfo;
+import io.hhplus.concert.application.waitingqueue.WaitingQueueDto.WaitingQueueWithOrderInfo;
 import io.hhplus.concert.domain.common.ServicePolicy;
 import io.hhplus.concert.domain.waitingqueue.exception.WaitingQueueErrorCode;
 import io.hhplus.concert.domain.waitingqueue.exception.WaitingQueueException;


### PR DESCRIPTION
## 요구 사항 반영 (주요 비지니스 로직 구현)
- [x] 비즈니스 Usecase 개발 및 통합 테스트 작성 

## 작업 내용 
- 대기열 usecase
   - 대기열 토큰 발급 (c1c0e1e1fe69e8411ce6e5c631f1db4ebc2d7da7)
   - 대기열 순번 조회 (0d11a513fa71d81a78825ba0a202d13ddf9f2051)
   - 대기열 검증 (0341e45f76f8cb2675c453306a912cdbe3035bb7)
   - 대기열 활성화 (d6491a630920744ce93bece02a7953985acbbe19)
- 유저 usecase
   - 포인트 사용/충전, 조회 (954d1bb19ce52e36ec90ee9ba88985a67b404103)
- 콘서트 usecase
   - 예약 가능한 날짜 조회 (eadc23c2a3039e7778343266f66f0651d900681e)
   - 예약 가능한 좌석 조회 (f9ace121476aa48acbbd6705fd545fc847b57842)
   - 좌석 예약 (9aed864322aa6a0c31fc15f64b15b460a45ca852)
   - 좌석 예약 동시성 제어 및 통합 테스트 (f451d1b27d4de42920854c75790cb43c7c2a81cc)
- 결제 usecase
   -  결제 기능 (10670bf5bfcf59255a53c3c77cf2ce39f09b068a)
   
## 리뷰 요청사항
- 지금처럼 Facade에 로직이 섞여도 괜찮을까요? service를 최대한 재사용할 수 있게 가볍게 가져갔는데, 그러다 보니 facade에서 지금처럼 로직 호출등이 잦은 것 같습니다.
