### PR TITLE
Step17 - Kafka 연동 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.32.0'
+	implementation 'org.springframework.kafka:spring-kafka'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -39,6 +40,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'com.h2database:h2'
 	testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 tasks.named('test') {

--- a/docker/kafka/kafka-compose.yml
+++ b/docker/kafka/kafka-compose.yml
@@ -1,0 +1,47 @@
+version: "3.8"
+
+services:
+  zookeeper1:
+    container_name: zookeeper1
+    image: confluentinc/cp-zookeeper:latest
+    restart: always
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  #    volumes:
+  #      - ./kafka/zookeeper_data:/var/lib/zookeeper/data
+  #      - ./kafka/zookeeper_logs:/var/lib/zookeeper/log
+
+  kafka1:
+    container_name: kafka1
+    image: confluentinc/cp-kafka:latest
+    restart: always
+    #    volumes:
+    #      - ./kafka/kafka_data:/var/lib/kafka/data
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    depends_on:
+      - zookeeper1
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    restart: always
+    depends_on:
+      - kafka1
+    ports:
+      - "8089:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: Local Kafka
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka1:9092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper1:2181

--- a/src/main/java/io/hhplus/concert/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/io/hhplus/concert/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,43 @@
+package io.hhplus.concert.config.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${kafka.consumer.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Value("${kafka.consumer.auto-offset-reset}")
+    private String AUTO_OFFSET_RESET;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET);
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+}

--- a/src/main/java/io/hhplus/concert/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/io/hhplus/concert/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.config.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${kafka.producer.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+}

--- a/src/test/java/io/hhplus/concert/infra/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/infra/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,63 @@
+package io.hhplus.concert.infra.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@EmbeddedKafka(partitions = 1,
+    brokerProperties = {"listeners=PLAINTEXT://localhost:9092"},
+    ports = {9092})
+@SpringBootTest
+public class KafkaIntegrationTest {
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Autowired
+    private KafkaTestConsumer kafkaTestConsumer;
+
+    @Value("${kafka.topics.test}")
+    private String topic;
+
+    @DisplayName("Kafka의 특정 토픽에 여러 번 메시지를 전송하고, 해당 토픽을 구독하는 컨슈머가 메시지를 소비한다.")
+    @Test
+    public void should_ConsumeMessages_When_ProducingMultipleMessages() {
+        // given
+        int sendCount = 5;
+        List<KafkaTestMessage> messages = new ArrayList<>();
+
+        // when
+        for(int i = 0; i < sendCount; ++i) {
+            String content = "test message " + i;
+            KafkaTestMessage message = new KafkaTestMessage(content, LocalDateTime.now());
+            messages.add(message);
+            kafkaTemplate.send(topic, message);
+        }
+
+        // then
+        await().pollInterval(500, TimeUnit.MILLISECONDS)
+            .atMost(5, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                List<KafkaTestMessage> consumedMessages = kafkaTestConsumer.getMessages();
+                assertThat(consumedMessages.size()).isEqualTo(sendCount);
+
+                for(int i = 0; i < sendCount; ++i) {
+                    KafkaTestMessage consumedMessage = consumedMessages.get(i);
+                    assertThat(consumedMessage.getMessage()).isEqualTo(messages.get(i).getMessage());
+                }
+            });
+    }
+}

--- a/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestConsumer.java
+++ b/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestConsumer.java
@@ -1,0 +1,38 @@
+package io.hhplus.concert.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+@Component
+public class KafkaTestConsumer {
+
+    private List<KafkaTestMessage> messages = new ArrayList<>();
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${kafka.topics.test}", groupId = "test_group")
+    public void consume(ConsumerRecord<String, Object> message, Acknowledgment ack) {
+        try {
+            Object value = message.value();
+            KafkaTestMessage deserializedMessage = objectMapper.convertValue(value, KafkaTestMessage.class);
+            log.info("Consumed message: {}", deserializedMessage.toString());
+            messages.add(deserializedMessage);
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("Failed to consume message", e);
+        }
+    }
+}

--- a/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestMessage.java
+++ b/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestMessage.java
@@ -1,0 +1,17 @@
+package io.hhplus.concert.infra.kafka;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaTestMessage {
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,3 +14,12 @@ spring:
     redis:
       port: 6379
       host: localhost
+
+kafka:
+  producer:
+    bootstrap-servers: localhost:9092
+  consumer:
+    bootstrap-servers: localhost:9092
+    auto-offset-reset: earliest
+  topics:
+    test: test-topic


### PR DESCRIPTION
## 요구 사항 반영 
- [x] docker 를 이용해 kafka 를 설치 및 실행하고 애플리케이션과 연동
- [x] 카프카 consumer, producer연동 및 테스트

## 작업 내용 
- kafka 설치
   - docker-compose를 통해 설치 ([파일 바로가기](https://github.com/cocomongg/concert-reservation-system/blob/feature/step17-v1/docker/kafka/kafka-compose.yml)) 
- kafka cli를 통한 테스트
  <details>
    <summary>자료 확인</summary>

    **1. 토픽 생성**

    ![스크린샷 2024-11-22 오전 1 36 32](https://github.com/user-attachments/assets/d77075f9-1d14-468e-8d11-b81e8d11bf39)

    ![스크린샷 2024-11-22 오전 1 37 03](https://github.com/user-attachments/assets/b006e8f9-e61e-420c-a8a3-d9040d865654)
    
     **2. produce message**
   
    ![스크린샷 2024-11-22 오전 1 41 25](https://github.com/user-attachments/assets/92b97cee-e74f-4d4e-b4ca-1ecbb02c8e1a)
    
    **3. message consume**
    
    ![스크린샷 2024-11-22 오전 1 41 30](https://github.com/user-attachments/assets/ab6d6381-e5c4-443c-befc-3ca82ea6ed53)
    
    ![스크린샷 2024-11-22 오전 1 42 15](https://github.com/user-attachments/assets/49912be4-9ec5-4bd7-a4ad-5c5beaae939e)
        
  </details>
- kafka - springBoot 연동 통합 테스트 ([커밋 바로가기](https://github.com/cocomongg/concert-reservation-system/compare/main...feature/step17-v1))