### PR TITLE
Step18 - Kafka producer,consumer 적용 및 Outbox Pattern적용

### DIFF
--- a/src/main/java/io/hhplus/concert/app/common/ServicePolicy.java
+++ b/src/main/java/io/hhplus/concert/app/common/ServicePolicy.java
@@ -9,4 +9,5 @@ public class ServicePolicy {
     public static final int WAITING_QUEUE_ACTIVATE_INTERVAL = 30_000;
     public static final TimeUnit TOKEN_ACTIVATE_INTERVAL_TIMEUNIT = TimeUnit.MINUTES;
     public static final String CACHE_CONCERT_PREFIX = "concert";
+    public static final int REPUBLISH_MESSAGE_INTERVAL = 60_000;
 }

--- a/src/main/java/io/hhplus/concert/app/common/error/CoreErrorType.java
+++ b/src/main/java/io/hhplus/concert/app/common/error/CoreErrorType.java
@@ -50,6 +50,16 @@ public enum CoreErrorType implements ErrorType {
         private final LogLevel logLevel;
     }
 
+    @Getter
+    @AllArgsConstructor
+    public enum PaymentOutbox implements ErrorType {
+        OUTBOX_NOT_FOUND(ErrorCode.NOT_FOUND, "Outbox not found", LogLevel.WARN);
+
+        private final ErrorCode errorCode;
+        private final String message;
+        private final LogLevel logLevel;
+    }
+
 //    @Getter
 //    @AllArgsConstructor
 //    public enum Payment implements ErrorType {

--- a/src/main/java/io/hhplus/concert/app/notification/interfaces/consumer/NotificationDonePaymentConsumer.java
+++ b/src/main/java/io/hhplus/concert/app/notification/interfaces/consumer/NotificationDonePaymentConsumer.java
@@ -1,0 +1,37 @@
+package io.hhplus.concert.app.notification.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.app.notification.domain.NotificationService;
+import io.hhplus.concert.app.notification.domain.model.NotificationMessage;
+import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationDonePaymentConsumer {
+
+    private final NotificationService notificationService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${kafka.topics.payment}", groupId = "${kafka.groups.notification}")
+    public void consumeDonePaymentEvent(ConsumerRecord<Object, Object> message, Acknowledgment ack) {
+        try {
+            DonePaymentEvent donePaymentEvent = objectMapper.convertValue(message.value(),
+                DonePaymentEvent.class);
+
+            NotificationMessage notificationMessage = new NotificationMessage("결제 완료",
+                "결제가 완료되었습니다.", donePaymentEvent.getPayment().getMemberId());
+            notificationService.sendNotification(notificationMessage);
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("NotificationConsumer consume error", e);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/application/PaymentFacade.java
+++ b/src/main/java/io/hhplus/concert/app/payment/application/PaymentFacade.java
@@ -2,6 +2,7 @@ package io.hhplus.concert.app.payment.application;
 
 import io.hhplus.concert.app.payment.application.PaymentDto.PaymentInfo;
 import io.hhplus.concert.app.common.ServicePolicy;
+import io.hhplus.concert.app.payment.domain.dto.PaymentCommand.CreatePaymentHistory;
 import io.hhplus.concert.app.payment.domain.event.publisher.PaymentEventPublisher;
 import io.hhplus.concert.app.concert.domain.service.ConcertService;
 import io.hhplus.concert.app.concert.domain.dto.ConcertCommand.ConfirmReservation;
@@ -49,9 +50,13 @@ public class PaymentFacade {
         // 좌석, 예약 정보 업데이트
         concertService.confirmReservation(new ConfirmReservation(concertSeatId, reservationId, dateTime));
 
-        // 결제 정보 저장
+        // 결제 정보,이력 저장
         Payment payment = paymentService.createPayment(new CreatePayment(memberId, reservationId,
             priceAmount, PaymentStatus.PAID, dateTime));
+
+        CreatePaymentHistory command = new CreatePaymentHistory(
+            payment.getId(), PaymentStatus.PAID, payment.getPaidAmount());
+        paymentService.createPaymentHistory(command);
 
         paymentEventPublisher.publish(new DonePaymentEvent(payment, token));
 

--- a/src/main/java/io/hhplus/concert/app/payment/application/PaymentOutboxScheduler.java
+++ b/src/main/java/io/hhplus/concert/app/payment/application/PaymentOutboxScheduler.java
@@ -1,0 +1,42 @@
+package io.hhplus.concert.app.payment.application;
+
+import static io.hhplus.concert.app.payment.domain.model.PaymentEventType.DONE_PAYMENT;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.app.common.ServicePolicy;
+import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
+import io.hhplus.concert.app.payment.domain.event.producer.PaymentEventProducer;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import io.hhplus.concert.app.payment.domain.service.PaymentOutboxService;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentOutboxScheduler {
+
+    private final PaymentOutboxService outboxService;
+    private final PaymentEventProducer paymentEventProducer;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(fixedRate = ServicePolicy.REPUBLISH_MESSAGE_INTERVAL)
+    public void republishMessage() {
+        List<PaymentOutbox> outboxesForRepublish = outboxService.getOutboxesForRepublish(
+            LocalDateTime.now());
+
+        for(PaymentOutbox outbox : outboxesForRepublish) {
+            try {
+                if(outbox.getEventType().equals(DONE_PAYMENT)) {
+                    DonePaymentEvent donePaymentEvent = objectMapper.convertValue(outbox.getPayload(), DonePaymentEvent.class);
+                    paymentEventProducer.produce(outbox.getTopic(), donePaymentEvent);
+                    outboxService.publishSuccess(outbox.getEventId());
+                }
+            } catch (Exception e) {
+                outboxService.publishFail(outbox.getEventId());
+            }
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/dto/PaymentOutboxCommand.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/dto/PaymentOutboxCommand.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.app.payment.domain.dto;
+
+import io.hhplus.concert.app.payment.domain.model.PaymentEventType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PaymentOutboxCommand {
+    @Getter
+    @AllArgsConstructor
+    public static class CreateOutbox {
+        private String eventId;
+        private PaymentEventType eventType;
+        private String topic;
+        private Object payload;
+        private LocalDateTime dateTime;
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/DonePaymentEvent.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/DonePaymentEvent.java
@@ -1,7 +1,7 @@
 package io.hhplus.concert.app.payment.domain.event;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.hhplus.concert.app.payment.domain.model.Payment;
-import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -9,7 +9,7 @@ public class DonePaymentEvent extends PaymentEvent {
     private final Payment payment;
     private final String token;
 
-    public DonePaymentEvent(Payment payment, String token) {
+    public DonePaymentEvent(@JsonProperty("payment") Payment payment, @JsonProperty("token") String token) {
         this.payment = payment;
         this.token = token;
     }

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/DonePaymentEvent.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/DonePaymentEvent.java
@@ -10,7 +10,6 @@ public class DonePaymentEvent extends PaymentEvent {
     private final String token;
 
     public DonePaymentEvent(Payment payment, String token) {
-        super(LocalDateTime.now());
         this.payment = payment;
         this.token = token;
     }

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/PaymentEvent.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/PaymentEvent.java
@@ -1,11 +1,17 @@
 package io.hhplus.concert.app.payment.domain.event;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public abstract class PaymentEvent {
+    private final String eventId;
     private final LocalDateTime publishAt;
+
+    public PaymentEvent() {
+        this.eventId = UUID.randomUUID().toString();
+        this.publishAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
@@ -17,18 +17,5 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class DonePaymentEventListener {
 
-    private final PaymentService paymentService;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleDonePaymentEvent(DonePaymentEvent event) {
-        try {
-            Payment payment = event.getPayment();
-            CreatePaymentHistory command = new CreatePaymentHistory(
-                payment.getId(), PaymentStatus.PAID, payment.getPaidAmount());
-            paymentService.createPaymentHistory(command);
-        } catch (Exception e) {
-            log.error("CreatePaymentHistoryEvent 처리 중 오류 발생", e);
-        }
-    }
 }

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
@@ -1,12 +1,14 @@
 package io.hhplus.concert.app.payment.domain.event.listener;
 
 import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
+import io.hhplus.concert.app.payment.domain.event.producer.PaymentEventProducer;
 import io.hhplus.concert.app.payment.domain.service.PaymentService;
 import io.hhplus.concert.app.payment.domain.dto.PaymentCommand.CreatePaymentHistory;
 import io.hhplus.concert.app.payment.domain.model.Payment;
 import io.hhplus.concert.app.payment.domain.model.PaymentStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -16,6 +18,14 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 @Component
 public class DonePaymentEventListener {
+    private final PaymentEventProducer paymentEventProducer;
 
+    @Value("${kafka.topics.payment}")
+    private String paymentTopic;
 
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void produceMessage(DonePaymentEvent event) {
+        paymentEventProducer.produce(paymentTopic, event);
+    }
 }

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/listener/DonePaymentEventListener.java
@@ -1,11 +1,12 @@
 package io.hhplus.concert.app.payment.domain.event.listener;
 
+import static io.hhplus.concert.app.payment.domain.dto.PaymentOutboxCommand.CreateOutbox;
+
 import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
 import io.hhplus.concert.app.payment.domain.event.producer.PaymentEventProducer;
-import io.hhplus.concert.app.payment.domain.service.PaymentService;
-import io.hhplus.concert.app.payment.domain.dto.PaymentCommand.CreatePaymentHistory;
-import io.hhplus.concert.app.payment.domain.model.Payment;
-import io.hhplus.concert.app.payment.domain.model.PaymentStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentEventType;
+import io.hhplus.concert.app.payment.domain.service.PaymentOutboxService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,9 +20,18 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class DonePaymentEventListener {
     private final PaymentEventProducer paymentEventProducer;
+    private final PaymentOutboxService outboxService;
 
     @Value("${kafka.topics.payment}")
     private String paymentTopic;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void createDonePaymentOutbox(DonePaymentEvent event) {
+        CreateOutbox command = new CreateOutbox(event.getEventId(),
+            PaymentEventType.DONE_PAYMENT, paymentTopic, event, LocalDateTime.now());
+
+        outboxService.createOutbox(command);
+    }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/io/hhplus/concert/app/payment/domain/event/producer/PaymentEventProducer.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/event/producer/PaymentEventProducer.java
@@ -1,0 +1,7 @@
+package io.hhplus.concert.app.payment.domain.event.producer;
+
+import io.hhplus.concert.app.payment.domain.event.PaymentEvent;
+
+public interface PaymentEventProducer {
+    void produce(String topic, PaymentEvent message);
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/model/OutboxStatus.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/model/OutboxStatus.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.app.payment.domain.model;
+
+public enum OutboxStatus {
+    INIT, SUCCESS, FAIL;
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/model/PaymentEventType.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/model/PaymentEventType.java
@@ -1,0 +1,5 @@
+package io.hhplus.concert.app.payment.domain.model;
+
+public enum PaymentEventType {
+    DONE_PAYMENT;
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/model/PaymentOutbox.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/model/PaymentOutbox.java
@@ -1,0 +1,87 @@
+package io.hhplus.concert.app.payment.domain.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hhplus.concert.app.payment.domain.dto.PaymentOutboxCommand.CreateOutbox;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "outbox")
+@Entity
+public class PaymentOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "event_id")
+    private String eventId;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "event_type")
+    private PaymentEventType eventType;
+
+    @Column(name = "topic")
+    private String topic;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "payload", columnDefinition = "json")
+    private ObjectNode payload;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "status")
+    private OutboxStatus status;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public PaymentOutbox(String eventId, PaymentEventType eventType, String topic, ObjectNode payload, LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.topic = topic;
+        this.payload = payload;
+        this.status = OutboxStatus.INIT;
+        this.createdAt = createdAt;
+    }
+
+    public static PaymentOutbox createInitOutbox(CreateOutbox command, ObjectNode payload) {
+        return PaymentOutbox.builder()
+            .eventId(command.getEventId())
+            .eventType(command.getEventType())
+            .topic(command.getTopic())
+            .payload(payload)
+            .status(OutboxStatus.INIT)
+            .createdAt(command.getDateTime())
+            .build();
+    }
+
+    public void publishSuccess() {
+        this.status = OutboxStatus.SUCCESS;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void publishFail() {
+        this.status = OutboxStatus.FAIL;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/repository/PaymentOutboxRepository.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/repository/PaymentOutboxRepository.java
@@ -1,0 +1,14 @@
+package io.hhplus.concert.app.payment.domain.repository;
+
+import io.hhplus.concert.app.payment.domain.model.OutboxStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PaymentOutboxRepository {
+    PaymentOutbox saveOutbox(PaymentOutbox outbox);
+
+    PaymentOutbox getOutbox(String eventId);
+
+    List<PaymentOutbox> getOutboxesForRepublish(OutboxStatus status, LocalDateTime thresholdTime);
+}

--- a/src/main/java/io/hhplus/concert/app/payment/domain/service/PaymentOutboxService.java
+++ b/src/main/java/io/hhplus/concert/app/payment/domain/service/PaymentOutboxService.java
@@ -1,0 +1,51 @@
+package io.hhplus.concert.app.payment.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hhplus.concert.app.payment.domain.dto.PaymentOutboxCommand.CreateOutbox;
+import io.hhplus.concert.app.payment.domain.model.OutboxStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import io.hhplus.concert.app.payment.domain.repository.PaymentOutboxRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PaymentOutboxService {
+    private final PaymentOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public PaymentOutbox getOutbox(String eventId) {
+        return outboxRepository.getOutbox(eventId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PaymentOutbox> getOutboxesForRepublish(LocalDateTime now) {
+        LocalDateTime retryThresholdTime = now.minusMinutes(5);
+        return outboxRepository.getOutboxesForRepublish(OutboxStatus.INIT, retryThresholdTime);
+    }
+
+    @Transactional
+    public PaymentOutbox createOutbox(CreateOutbox command) {
+        ObjectNode payload = objectMapper.valueToTree(command.getPayload());
+        PaymentOutbox outbox = PaymentOutbox.createInitOutbox(command, payload);
+
+        return outboxRepository.saveOutbox(outbox);
+    }
+
+    @Transactional
+    public void publishSuccess(String eventId) {
+        PaymentOutbox outbox = this.getOutbox(eventId);
+        outbox.publishSuccess();
+    }
+
+    @Transactional
+    public void publishFail(String eventId) {
+        PaymentOutbox outbox = this.getOutbox(eventId);
+        outbox.publishFail();
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/infra/db/PaymentOutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/concert/app/payment/infra/db/PaymentOutboxJpaRepository.java
@@ -1,0 +1,18 @@
+package io.hhplus.concert.app.payment.infra.db;
+
+import io.hhplus.concert.app.payment.domain.model.OutboxStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentOutboxJpaRepository extends JpaRepository<PaymentOutbox, Long> {
+    Optional<PaymentOutbox> findByEventId(String eventId);
+
+    @Query("select o from PaymentOutbox o where o.status = :status and o.createdAt < :thresholdTime")
+    List<PaymentOutbox> findAllByStatusTargetDatetime(OutboxStatus status, LocalDateTime thresholdTime);
+}

--- a/src/main/java/io/hhplus/concert/app/payment/infra/db/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert/app/payment/infra/db/PaymentOutboxRepositoryImpl.java
@@ -1,0 +1,34 @@
+package io.hhplus.concert.app.payment.infra.db;
+
+import io.hhplus.concert.app.common.error.CoreErrorType;
+import io.hhplus.concert.app.common.error.CoreException;
+import io.hhplus.concert.app.payment.domain.model.OutboxStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import io.hhplus.concert.app.payment.domain.repository.PaymentOutboxRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
+
+    private final PaymentOutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public PaymentOutbox saveOutbox(PaymentOutbox outbox) {
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public PaymentOutbox getOutbox(String eventId) {
+        return outboxJpaRepository.findByEventId(eventId)
+            .orElseThrow(() -> new CoreException(CoreErrorType.PaymentOutbox.OUTBOX_NOT_FOUND));
+    }
+
+    @Override
+    public List<PaymentOutbox> getOutboxesForRepublish(OutboxStatus status, LocalDateTime thresholdTime) {
+        return outboxJpaRepository.findAllByStatusTargetDatetime(status, thresholdTime);
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/payment/infra/kafka/PaymentEventKafkaProducer.java
+++ b/src/main/java/io/hhplus/concert/app/payment/infra/kafka/PaymentEventKafkaProducer.java
@@ -1,0 +1,20 @@
+package io.hhplus.concert.app.payment.infra.kafka;
+
+import io.hhplus.concert.app.payment.domain.event.PaymentEvent;
+import io.hhplus.concert.app.payment.domain.event.producer.PaymentEventProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentEventKafkaProducer implements PaymentEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void produce(String topic, PaymentEvent message) {
+        kafkaTemplate.send(topic, message);
+    }
+}
+

--- a/src/main/java/io/hhplus/concert/app/payment/interfaces/consumer/DonePaymentMessageConsumer.java
+++ b/src/main/java/io/hhplus/concert/app/payment/interfaces/consumer/DonePaymentMessageConsumer.java
@@ -1,0 +1,33 @@
+package io.hhplus.concert.app.payment.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
+import io.hhplus.concert.app.payment.domain.service.PaymentOutboxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DonePaymentMessageConsumer {
+    private final PaymentOutboxService outboxService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${kafka.topics.payment}", groupId = "${kafka.groups.payment}")
+    public void consume(ConsumerRecord<String, Object> message, Acknowledgment ack) {
+        try {
+            DonePaymentEvent donePaymentEvent = objectMapper.convertValue(message.value(),
+                DonePaymentEvent.class);
+
+            outboxService.publishSuccess(donePaymentEvent.getEventId());
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("DonePaymentMessageConsumer consume error", e);
+        }
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/waitingqueue/application/WaitingQueueFacade.java
+++ b/src/main/java/io/hhplus/concert/app/waitingqueue/application/WaitingQueueFacade.java
@@ -5,15 +5,16 @@ import static io.hhplus.concert.app.common.ServicePolicy.WAITING_QUEUE_ACTIVATE_
 import static io.hhplus.concert.app.common.ServicePolicy.WAITING_QUEUE_ACTIVATE_INTERVAL;
 import static io.hhplus.concert.app.common.ServicePolicy.WAITING_QUEUE_EXPIRED_MINUTES;
 
-import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueService;
-import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueTokenGenerator;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ActivateWaitingTokens;
+import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ExpireToken;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.InsertWaitingQueue;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.CheckTokenActivate;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.GetRemainingWaitTimeSeconds;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
 import io.hhplus.concert.app.waitingqueue.domain.model.WaitingQueueTokenInfo;
 import io.hhplus.concert.app.waitingqueue.domain.model.WaitingTokenWithOrderInfo;
+import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueService;
+import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueTokenGenerator;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -58,7 +59,7 @@ public class WaitingQueueFacade {
         return waitingQueueService.activateToken(command);
     }
 
-//    public Long expireWaitingQueues(LocalDateTime currentTime) {
-//        return waitingQueueService.expireToken(currentTime);
-//    }
+    public void expireToken(String token) {
+        waitingQueueService.expireToken(new ExpireToken(token));
+    }
 }

--- a/src/main/java/io/hhplus/concert/app/waitingqueue/domain/dto/WaitingQueueCommand.java
+++ b/src/main/java/io/hhplus/concert/app/waitingqueue/domain/dto/WaitingQueueCommand.java
@@ -21,4 +21,10 @@ public class WaitingQueueCommand {
         private final long expireTime;
         private final TimeUnit timeUnit;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ExpireToken {
+        private final String token;
+    }
 }

--- a/src/main/java/io/hhplus/concert/app/waitingqueue/domain/event/DonePaymentTokenExpireHandler.java
+++ b/src/main/java/io/hhplus/concert/app/waitingqueue/domain/event/DonePaymentTokenExpireHandler.java
@@ -1,7 +1,7 @@
 package io.hhplus.concert.app.waitingqueue.domain.event;
 
 import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
-import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
+import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ExpireToken;
 import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +22,7 @@ public class DonePaymentTokenExpireHandler {
     public void handle(DonePaymentEvent event) {
         try {
             String token = event.getToken();
-            waitingQueueService.expireToken(new GetWaitingQueueCommonQuery(token));
+            waitingQueueService.expireToken(new ExpireToken(token));
         } catch (Exception e) {
             log.error("ExpireTokenEvent 처리 중 오류 발생", e);
         }

--- a/src/main/java/io/hhplus/concert/app/waitingqueue/domain/service/WaitingQueueService.java
+++ b/src/main/java/io/hhplus/concert/app/waitingqueue/domain/service/WaitingQueueService.java
@@ -3,6 +3,7 @@ package io.hhplus.concert.app.waitingqueue.domain.service;
 import io.hhplus.concert.app.common.error.CoreErrorType;
 import io.hhplus.concert.app.common.error.CoreException;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ActivateWaitingTokens;
+import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ExpireToken;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.InsertWaitingQueue;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.CheckTokenActivate;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.GetRemainingWaitTimeSeconds;
@@ -74,7 +75,7 @@ public class WaitingQueueService {
         return activateCount;
     }
 
-    public void expireToken(GetWaitingQueueCommonQuery query) {
-        waitingQueueRepository.expireToken(query.getToken());
+    public void expireToken(ExpireToken command) {
+        waitingQueueRepository.expireToken(command.getToken());
     }
 }

--- a/src/main/java/io/hhplus/concert/app/waitingqueue/interfaces/consumer/WaitingQueueDonePaymentConsumer.java
+++ b/src/main/java/io/hhplus/concert/app/waitingqueue/interfaces/consumer/WaitingQueueDonePaymentConsumer.java
@@ -1,0 +1,35 @@
+package io.hhplus.concert.app.waitingqueue.interfaces.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert.app.payment.domain.event.DonePaymentEvent;
+import io.hhplus.concert.app.waitingqueue.application.WaitingQueueFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class WaitingQueueDonePaymentConsumer {
+
+    private final WaitingQueueFacade waitingQueueFacade;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "${kafka.topics.payment}", groupId = "${kafka.groups.waitingQueue}")
+    public void consumeDonePaymentEvent(ConsumerRecord<String, Object> message, Acknowledgment ack) {
+        try {
+            DonePaymentEvent donePaymentEvent = objectMapper.convertValue(message.value(),
+                DonePaymentEvent.class);
+
+            waitingQueueFacade.expireToken(donePaymentEvent.getToken());
+
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("WaitingQueueConsumer consume error", e);
+        }
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,16 @@ spring:
       host: localhost
   cache:
     type: redis
+
+kafka:
+  producer:
+    bootstrap-servers: localhost:29092
+  consumer:
+    bootstrap-servers: localhost:29092
+    auto-offset-reset: earliest
+  topics:
+    payment: payment-done-topic
+  groups:
+    payment: payment-group
+    waitingQueue: waiting-queue-group
+    notification: notification-group

--- a/src/test/java/io/hhplus/concert/app/payment/domain/service/PaymentOutboxServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/app/payment/domain/service/PaymentOutboxServiceIntegrationTest.java
@@ -1,0 +1,224 @@
+package io.hhplus.concert.app.payment.domain.service;
+
+import static io.hhplus.concert.app.payment.domain.model.PaymentEventType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hhplus.concert.app.common.error.CoreErrorType;
+import io.hhplus.concert.app.common.error.CoreException;
+import io.hhplus.concert.app.payment.domain.dto.PaymentOutboxCommand.CreateOutbox;
+import io.hhplus.concert.app.payment.domain.model.OutboxStatus;
+import io.hhplus.concert.app.payment.domain.model.PaymentEventType;
+import io.hhplus.concert.app.payment.domain.model.PaymentOutbox;
+import io.hhplus.concert.app.payment.infra.db.PaymentOutboxJpaRepository;
+import io.hhplus.concert.support.DatabaseCleanUp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class PaymentOutboxServiceIntegrationTest {
+
+    @Autowired
+    private PaymentOutboxService outboxService;
+
+    @Autowired
+    private PaymentOutboxJpaRepository outboxJpaRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    public void teardown() {
+        databaseCleanUp.execute();
+    }
+
+    @DisplayName("getOutbox() test")
+    @Nested
+    class GetOutboxTest {
+        @DisplayName("eventId에 해당하는 Outbox를 반환한다.")
+        @Test
+        void should_ReturnOutbox_When_GivenEventId() {
+            // given
+            String eventId = "testEventId";
+            PaymentOutbox savedOutbox = outboxJpaRepository.save(
+                new PaymentOutbox(eventId, DONE_PAYMENT, "testTopic", null, null));
+
+            // when
+            PaymentOutbox result = outboxService.getOutbox(eventId);
+
+            // then
+            assertThat(result.getId()).isEqualTo(savedOutbox.getId());
+            assertThat(result.getEventId()).isEqualTo(eventId);
+        }
+
+        @DisplayName("eventId에 해당하는 Outbox가 없으면 CoreException이 발생한다.")
+        @Test
+        void should_ThrowCoreException_When_OutboxNotFound() {
+            // given
+            String eventId = "testEventId";
+
+            // when, then
+            assertThatThrownBy(() -> outboxService.getOutbox(eventId))
+                .isInstanceOf(CoreException.class)
+                .hasMessage(CoreErrorType.PaymentOutbox.OUTBOX_NOT_FOUND.getMessage());
+        }
+    }
+
+    @DisplayName("getOutboxesForRepublish() test")
+    @Nested
+    class GetOutboxesForRepublishTest {
+        @DisplayName("주어진 일시 보다 5분 전에 생성된 INIT상태의 Outbox 목록을 반환한다.")
+        @Test
+        void should_ReturnOutboxes_whenCreatedBeforeGivenTimeAndStatusIsInit() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            int outboxForRepublishCount = 5;
+            List<PaymentOutbox> outboxList = new ArrayList<>();
+            for(int i = 0; i < outboxForRepublishCount; ++i) {
+                PaymentOutbox outboxForRepublish = PaymentOutbox.builder()
+                    .eventId("eventId" + i)
+                    .eventType(DONE_PAYMENT)
+                    .topic("topic" + i)
+                    .status(OutboxStatus.INIT)
+                    .createdAt(now.minusMinutes(10))
+                    .build();
+
+                outboxList.add(outboxJpaRepository.save(outboxForRepublish));
+            }
+
+            PaymentOutbox outboxNotForRepublish1 = PaymentOutbox.builder()
+                .eventId("eventIdNotForRepublish1")
+                .eventType(DONE_PAYMENT)
+                .topic("topicNotForRepublish1")
+                .status(OutboxStatus.INIT)
+                .createdAt(now.minusMinutes(4))
+                .build();
+
+            PaymentOutbox outboxNotForRepublish2 = PaymentOutbox.builder()
+                .eventId("eventIdNotForRepublish1")
+                .eventType(DONE_PAYMENT)
+                .topic("topicNotForRepublish1")
+                .status(OutboxStatus.SUCCESS)
+                .createdAt(now.minusMinutes(10))
+                .build();
+
+            outboxList.addAll(List.of(outboxNotForRepublish1, outboxNotForRepublish2));
+            outboxJpaRepository.saveAll(outboxList);
+
+            // when
+            List<PaymentOutbox> result = outboxService.getOutboxesForRepublish(now);
+
+            // then
+            assertThat(result.size()).isEqualTo(outboxForRepublishCount);
+            for(PaymentOutbox outbox : result) {
+                assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.INIT);
+                assertThat(outbox.getCreatedAt()).isBefore(now.minusMinutes(5));
+            }
+        }
+    }
+
+    @DisplayName("createOutbox() test")
+    @Nested
+    class CreateOutboxTest {
+        @DisplayName("입력된 값을 통해 INIT상태의 Outbox를 반환한다.")
+        @Test
+        void should_ReturnOutbox_When_GivenCreateOutboxCommand() {
+            // given
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("key1", "value1");
+            CreateOutbox command = new CreateOutbox("testEventId", DONE_PAYMENT,
+                "testTopic", payload, LocalDateTime.now());
+
+            // when
+            PaymentOutbox result = outboxService.createOutbox(command);
+
+            // then
+            assertThat(result.getEventId()).isEqualTo(command.getEventId());
+            assertThat(result.getEventType()).isEqualTo(command.getEventType());
+            assertThat(result.getTopic()).isEqualTo(command.getTopic());
+            assertThat(result.getPayload()).isEqualTo(objectMapper.valueToTree(command.getPayload()));
+            assertThat(result.getStatus()).isEqualTo(OutboxStatus.INIT);
+        }
+
+        @DisplayName("입력된 값을 통해 INIT상태의 Outbox를 저장한다.")
+        @Test
+        void should_SaveOutbox_When_GivenCreateOutboxCommand() {
+            // given
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("key1", "value1");
+            CreateOutbox command = new CreateOutbox("testEventId", DONE_PAYMENT,
+                "testTopic", payload, LocalDateTime.now());
+
+            // when
+            PaymentOutbox result = outboxService.createOutbox(command);
+
+            // then
+            PaymentOutbox savedOutbox = outboxJpaRepository.findById(result.getId()).orElse(null);
+            assertThat(savedOutbox).isNotNull();
+            assertThat(savedOutbox.getEventId()).isEqualTo(command.getEventId());
+            assertThat(savedOutbox.getEventType()).isEqualTo(command.getEventType());
+            assertThat(savedOutbox.getTopic()).isEqualTo(command.getTopic());
+            assertThat(result.getPayload()).isEqualTo(objectMapper.valueToTree(command.getPayload()));
+            assertThat(savedOutbox.getStatus()).isEqualTo(OutboxStatus.INIT);
+        }
+    }
+
+    @DisplayName("publishSuccess() test")
+    @Nested
+    class PublishSuccessTest {
+        @DisplayName("eventId에 해당하는 Outbox의 상태를 SUCCESS로 변경한다.")
+        @Test
+        void should_ChangeOutboxStatusToSuccess_When_GivenEventId() {
+            // given
+            String eventId = "testEventId";
+            PaymentOutbox outbox = outboxJpaRepository.save(
+                new PaymentOutbox(eventId, DONE_PAYMENT, "testTopic", null, null));
+
+            // when
+            outboxService.publishSuccess(eventId);
+
+            // then
+            PaymentOutbox updatedOutbox = outboxJpaRepository.findById(outbox.getId()).orElse(null);
+            assertThat(updatedOutbox).isNotNull();
+            assertThat(updatedOutbox.getStatus()).isEqualTo(OutboxStatus.SUCCESS);
+        }
+    }
+
+    @DisplayName("publishFail() test")
+    @Nested
+    class PublishFailTest {
+        @DisplayName("eventId에 해당하는 Outbox의 상태를 FAIL로 변경한다.")
+        @Test
+        void should_ChangeOutboxStatusToFail_When_GivenEventId() {
+            // given
+            String eventId = "testEventId";
+            PaymentOutbox outbox = outboxJpaRepository.save(
+                new PaymentOutbox(eventId, DONE_PAYMENT, "testTopic", null, null));
+
+            // when
+            outboxService.publishFail(eventId);
+
+            // then
+            PaymentOutbox updatedOutbox = outboxJpaRepository.findById(outbox.getId()).orElse(null);
+            assertThat(updatedOutbox).isNotNull();
+            assertThat(updatedOutbox.getStatus()).isEqualTo(OutboxStatus.FAIL);
+        }
+    }
+
+}

--- a/src/test/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueServiceIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/domain/waitingqueue/WaitingQueueServiceIntegrationTest.java
@@ -3,17 +3,18 @@ package io.hhplus.concert.domain.waitingqueue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueService;
 import io.hhplus.concert.app.common.error.CoreErrorType;
 import io.hhplus.concert.app.common.error.CoreException;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ActivateWaitingTokens;
+import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.ExpireToken;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueCommand.InsertWaitingQueue;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.CheckTokenActivate;
 import io.hhplus.concert.app.waitingqueue.domain.dto.WaitingQueueQuery.GetWaitingQueueCommonQuery;
+import io.hhplus.concert.app.waitingqueue.domain.model.TokenMeta;
 import io.hhplus.concert.app.waitingqueue.domain.model.WaitingQueueTokenInfo;
 import io.hhplus.concert.app.waitingqueue.domain.model.WaitingQueueTokenStatus;
+import io.hhplus.concert.app.waitingqueue.domain.service.WaitingQueueService;
 import io.hhplus.concert.app.waitingqueue.infra.redis.RedisRepository;
-import io.hhplus.concert.app.waitingqueue.domain.model.TokenMeta;
 import io.hhplus.concert.support.RedisCleanUp;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -233,10 +234,8 @@ class WaitingQueueServiceIntegrationTest {
             redisRepository.setStringValue("active_queue:" + activeToken,
                 new TokenMeta(LocalDateTime.now()), Duration.ofMinutes(10));
 
-            GetWaitingQueueCommonQuery query = new GetWaitingQueueCommonQuery(activeToken);
-
             // when
-            waitingQueueService.expireToken(query);
+            waitingQueueService.expireToken(new ExpireToken(activeToken));
 
             // then
             boolean inSet = redisRepository.isInSet("active_queue", activeToken);

--- a/src/test/java/io/hhplus/concert/infra/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/infra/kafka/KafkaIntegrationTest.java
@@ -17,9 +17,6 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
-@EmbeddedKafka(partitions = 1,
-    brokerProperties = {"listeners=PLAINTEXT://localhost:9092"},
-    ports = {9092})
 @SpringBootTest
 public class KafkaIntegrationTest {
 
@@ -28,9 +25,6 @@ public class KafkaIntegrationTest {
 
     @Autowired
     private KafkaTestConsumer kafkaTestConsumer;
-
-    @Value("${kafka.topics.test}")
-    private String topic;
 
     @DisplayName("Kafka의 특정 토픽에 여러 번 메시지를 전송하고, 해당 토픽을 구독하는 컨슈머가 메시지를 소비한다.")
     @Test
@@ -44,7 +38,7 @@ public class KafkaIntegrationTest {
             String content = "test message " + i;
             KafkaTestMessage message = new KafkaTestMessage(content, LocalDateTime.now());
             messages.add(message);
-            kafkaTemplate.send(topic, message);
+            kafkaTemplate.send("test-topic", message);
         }
 
         // then

--- a/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestConsumer.java
+++ b/src/test/java/io/hhplus/concert/infra/kafka/KafkaTestConsumer.java
@@ -22,7 +22,7 @@ public class KafkaTestConsumer {
 
     private final ObjectMapper objectMapper;
 
-    @KafkaListener(topics = "${kafka.topics.test}", groupId = "test_group")
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
     public void consume(ConsumerRecord<String, Object> message, Acknowledgment ack) {
         try {
             Object value = message.value();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -17,9 +17,13 @@ spring:
 
 kafka:
   producer:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
   consumer:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
     auto-offset-reset: earliest
   topics:
-    test: test-topic
+    payment: payment-done-topic
+  groups:
+    payment: payment-group
+    waitingQueue: waiting-queue-group
+    notification: notification-group


### PR DESCRIPTION
## 요구 사항 반영 
- [x] 애플리케이션 이벤트를 카프카 메세지 발행으로 변경
- [x] Outbox Pattern 적용
- [x] Scheduler를 통해 카프카의 발행이 실패한 케이스에 대한 재처리를 구현 

## 작업 내용 
- diff([바로가기](https://github.com/cocomongg/concert-reservation-system/compare/feature/step17-v1...feature/step18-v1))

## 리뷰 포인트
- kafka 테스트 너무 어렵습니다... 보통 현업에서는 어떻게 producer와 consumer에 대해 테스트를 작성하는지 궁금합니다.